### PR TITLE
No Internet Required + k8s v1.14.9

### DIFF
--- a/files/kubeconfig.yml
+++ b/files/kubeconfig.yml
@@ -1,0 +1,6 @@
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: v1.14.9

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -101,12 +101,12 @@ __CUSTOMIZE_PHOTON__
     # Setup k8s
     echo -e "\e[92mSetting up k8s ..." > /dev/console
     HOME=/root
-    kubeadm init --ignore-preflight-errors SystemVerification
+    kubeadm init --ignore-preflight-errors SystemVerification --skip-token-print --config /root/kubeconfig.yml
     mkdir -p $HOME/.kube
     cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
     chown $(id -u):$(id -g) $HOME/.kube/config
     echo -e "\e[92mDeloying kubeadm ..." > /dev/console
-    kubectl --kubeconfig /root/.kube/config apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl --kubeconfig /root/.kube/config version | base64 | tr -d '\n')"
+    kubectl --kubeconfig /root/.kube/config apply -f /root/weave.yaml
     kubectl --kubeconfig /root/.kube/config taint nodes --all node-role.kubernetes.io/master-
     echo -e "\e[92mStarting k8s ..." > /dev/console
     systemctl enable kubelet.service

--- a/files/tinywww-debug.yml
+++ b/files/tinywww-debug.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - image: embano1/tinywww:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: tinywww
         ports:
           - containerPort: 8100

--- a/files/tinywww.yml
+++ b/files/tinywww.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - image: embano1/tinywww:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: tinywww
         ports:
           - containerPort: 8100

--- a/getting-started.md
+++ b/getting-started.md
@@ -7,7 +7,6 @@
 * 2 vCPU and 8GB of memory for VEBA
 * vCenter Server 6.x or greater
 * Account to login to vCenter Server (readOnly is sufficient)
-* Internet connectivity required for VEBA for setup
 
 **Step 1** - Download the VEBA Virtual Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vcenter-event-broker-appliance).
 
@@ -15,7 +14,7 @@
 
 *Networking*
 
-  * Hostname - The FQDN of the VEBA Appliance. If you do not have DNS in your enviornment, make sure the hsotname provide is resolvable from your desktop which may require you to manually add a hosts entry. Proper DNS resolution is recommended
+  * Hostname - The FQDN of the VEBA Appliance. If you do not have DNS in your environment, make sure the hostname provide is resolvable from your desktop which may require you to manually add a hosts entry. Proper DNS resolution is recommended
   * IP Address - The IP Address of the VEBA Appliance
   * Netmask Prefix - CIDR Notation (e.g. 24 = 255.255.255.0)
   * Gateway - The Network Gateway address
@@ -30,7 +29,7 @@
 *vSphere*
 
   * vCenter Server - This FQDN or IP Address of your vCenter Server that you wish to associate this VEBA Appliance to for Event subscription
-  * vCenter Username - The username to login to vCenter Server, as mentioned earlier, readOnly account is sufficent
+  * vCenter Username - The username to login to vCenter Server, as mentioned earlier, readOnly account is sufficient
   * vCenter Password - The password to the vCenter Username
   * Disable vCenter Server TLS Verification - If you have a self-signed SSL Certificate, you will need to check this box
 
@@ -50,7 +49,7 @@ OpenFaaS UI: https://[IP]
 
 **Step 4** - You can verify that everything was deployed correctly by opening a web browser to the OpenFaaS UI and logging in with the Admin credentials (user:admin) you had specified as part of the OVA deployment.
 
-At this point, you have successfully deployed the VEBA Appliance and you are ready to start deploying your functions! 
+At this point, you have successfully deployed the VEBA Appliance and you are ready to start deploying your functions!
 
 
 ## Function Deployment
@@ -97,7 +96,7 @@ Take a note of the `urn:...` for `demotag1` as we will need it for the next step
 
 ### Get the example function
 
-Clone this repository which contains the example functions. 
+Clone this repository which contains the example functions.
 
 ```bash
 git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
@@ -184,7 +183,7 @@ If your VM did not get the tag attached, verify:
 - Check the logs (`kubectl` is installed and configured locally on the appliance)):
 
 ```bash
-faas-cli logs pytag-fn --follow --tls-no-verify 
+faas-cli logs pytag-fn --follow --tls-no-verify
 
 # Successful log message in the OpenFaaS tagging function
 2019/01/25 23:48:55 Forking fprocess.

--- a/photon-dev.json
+++ b/photon-dev.json
@@ -70,10 +70,24 @@
   "provisioners": [
     {
       "type": "shell",
+      "expect_disconnect" : true,
       "scripts": [
         "scripts/photon-settings.sh",
-        "scripts/photon-docker.sh",
-        "scripts/photon-openfaas.sh"
+        "scripts/photon-docker.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "pause_before": "20s",
+      "scripts": [
+        "scripts/photon-containers.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/photon-openfaas.sh",
+        "scripts/photon-cleanup.sh"
       ]
     },
     {
@@ -100,6 +114,11 @@
       "type": "file",
       "source": "files/tinywww-debug.yml",
       "destination": "/root/tinywww-debug.yml"
+    },
+    {
+      "type": "file",
+      "source": "files/kubeconfig.yml",
+      "destination": "/root/kubeconfig.yml"
     }
   ],
   "post-processors": [

--- a/photon-version.json
+++ b/photon-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Photon Build for vCenter Event Broker Appliance",
   "vm_name": "vCenter_Event_Broker_Appliance",
   "iso_checksum": "93d0cde8da51f9208713d895b5b85b86980d2a72e710f55f0e65bc82c299dd9a7ebedc8f30d5f4d18c1a389c76a961e8a14b02416692204d31d77e1e4792f37d",

--- a/photon.json
+++ b/photon.json
@@ -39,7 +39,6 @@
       "vmx_data": {
         "numvcpus": "{{ user `numvcpus` }}",
         "memsize": "{{ user `ramsize` }}",
-
         "ethernet0.networkName": "{{ user `builder_host_portgroup` }}",
         "ethernet0.present": "TRUE",
         "ethernet0.startConnected": "TRUE",
@@ -53,9 +52,22 @@
   "provisioners": [
     {
       "type": "shell",
+      "expect_disconnect" : true,
       "scripts": [
         "scripts/photon-settings.sh",
-        "scripts/photon-docker.sh",
+        "scripts/photon-docker.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "pause_before": "20s",
+      "scripts": [
+        "scripts/photon-containers.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
         "scripts/photon-openfaas.sh",
         "scripts/photon-cleanup.sh"
       ]
@@ -84,6 +96,11 @@
       "type": "file",
       "source": "files/tinywww-debug.yml",
       "destination": "/root/tinywww-debug.yml"
+    },
+    {
+      "type": "file",
+      "source": "files/kubeconfig.yml",
+      "destination": "/root/kubeconfig.yml"
     }
   ],
   "post-processors": [

--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -eux
+# Copyright 2019 VMware, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2
+
+echo '> Downloading weave.yaml'
+curl -L https://cloud.weave.works/k8s/net?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxNCIsIEdpdFZlcnNpb246InYxLjE0LjYiLCBHaXRDb21taXQ6Ijk2ZmFjNWNkMTNhNWRjMDY0ZjdkOWY0ZjIzMDMwYTZhZWZhY2U2Y2MiLCBHaXRUcmVlU3RhdGU6ImFyY2hpdmUiLCBCdWlsZERhdGU6IjIwMTktMTAtMzFUMDY6MDQ6MDNaIiwgR29WZXJzaW9uOiJnbzEuMTMuMyIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTQiLCBHaXRWZXJzaW9uOiJ2MS4xNC45IiwgR2l0Q29tbWl0OiI1MDBmNWFiYTgwZDcxMjUzY2MwMWFjNmE4NjIyYjgzNzdmNGE3ZWY5IiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAxOS0xMS0xM1QxMToxMzowNFoiLCBHb1ZlcnNpb246ImdvMS4xMi4xMiIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9Cg -o /root/weave.yaml
+sed -i '/^          hostNetwork:.*/i \              imagePullPolicy: IfNotPresent' /root/weave.yaml
+
+echo '> Pre-Downloading Kubeadm Docker Containers'
+
+CONTAINERS=(
+k8s.gcr.io/kube-apiserver:v1.14.9
+k8s.gcr.io/kube-controller-manager:v1.14.9
+k8s.gcr.io/kube-scheduler:v1.14.9
+k8s.gcr.io/kube-proxy:v1.14.9
+k8s.gcr.io/pause:3.1
+k8s.gcr.io/etcd:3.3.10
+k8s.gcr.io/coredns:1.3.1
+docker.io/weaveworks/weave-kube:2.6.0
+docker.io/weaveworks/weave-npc:2.6.0
+embano1/tinywww:latest
+projectcontour/contour:v1.0.0-beta.1
+openfaas/faas-netes:0.9.0
+openfaas/gateway:0.17.4
+openfaas/vcenter-connector:0.4.0
+openfaas/basic-auth-plugin:0.17.0
+openfaas/queue-worker:0.8.0
+openfaas/faas-idler:0.2.1
+envoyproxy/envoy:v1.11.1
+prom/prometheus:v2.11.0
+prom/alertmanager:v0.18.0
+nats-streaming:0.11.2
+)
+
+for i in ${CONTAINERS[@]};
+do
+	docker pull $i
+done

--- a/scripts/photon-docker.sh
+++ b/scripts/photon-docker.sh
@@ -9,6 +9,7 @@
 echo '> Enabling Docker...'
 
 systemctl enable docker
+reboot
 
 echo '> Done'
 

--- a/scripts/photon-openfaas.sh
+++ b/scripts/photon-openfaas.sh
@@ -7,6 +7,7 @@ echo '> Downloading FaaS-Netes...'
 git clone https://github.com/openfaas/faas-netes
 cd faas-netes
 git checkout 0.9.2
+sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' yaml/*.yml
 cd ..
 
 echo '> Downloading OpenFaaS vCenter Connector...'
@@ -16,12 +17,14 @@ git checkout fefb5881ab2dfe05207f7f0b65c37ef5d1db34af
 cd ..
 mv vcenter-connector/yaml/kubernetes/connector-dep.yml vcenter-connector/yaml/kubernetes/connector-dep.yml.orig
 cp vcenter-connector/yaml/kubernetes/connector-dep.yml.orig vcenter-connector/yaml/kubernetes/connector-dep.yml
+sed -i '/image:.*/a \        imagePullPolicy: IfNotPresent' vcenter-connector/yaml/kubernetes/connector-dep.yml
 
 echo '> Downloading Contour...'
 git clone https://github.com/projectcontour/contour.git
 cd contour
 git checkout v1.0.0-beta.1
 sed -i '/^---/i \      dnsPolicy: ClusterFirstWithHostNet\n      hostNetwork: true' examples/contour/03-envoy.yaml
+sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' examples/contour/*.yaml
 cd ..
 
 cat << EOF > /etc/issue


### PR DESCRIPTION
* Changed to the latest k8s v1.14.9 via Kubeadm configuration file as the default version shipped w/PhotonOS 3.0 is still v1.14.6 which may not include all latest CVEs
* Pre-download all required Docker Containers, so internet connectivity is not required for initial VEBA setup
* Update ImagePullPolicy from Always to IfNotPresent which is required or k8s deployment spec will fail as it tries to pull Docker Container even though its already present
* Minor doc/typo fixes

Signed-off-by: William Lam <wlam@vmware.com>