### PR TITLE
New example for host maintenance

### DIFF
--- a/examples/powercli/hostmaint-alarms/README.md
+++ b/examples/powercli/hostmaint-alarms/README.md
@@ -1,0 +1,31 @@
+## Description
+
+This example will disable alarm actions on a host while it is in maintenance mode.  It deploys two functions that use the same PowerCLI script.  The first function subscribes to the `entered.maintenance.mode` event to run when a host is put into maintenance mode and disable alarms.  The second function subscribes to the `exit.maintenance.mode` event to re-enable alarms when the host exits maintenance mode.  There is an accompanying blog post with more details:  [Automate Host Maintenance with the vCenter Event Broker Appliance
+](https://doogleit.github.io/2019/11/automate-host-maintenance-with-the-vcenter-event-broker-appliance/)
+
+## Deployment
+
+1. Update the vcconfig.json file with your vCenter information and create the secret.  If you already have this secret created from one of the other PowerCLI examples you can skip this step.
+
+```json
+{
+    "VC" : "vcenter-hostname",
+    "VC_USERNAME" : "veba@vsphere.local",
+    "VC_PASSWORD" : "FillMeIn"
+}
+```
+```shell
+faas-cli secret create vcconfig --from-file=vcconfig.json --tls-no-verify
+```
+
+2. Update the gateway in the stack.yml file with your vCenter Event Broker Appliance address and deploy the functions.
+```yaml
+provider:
+  name: faas
+  gateway: https://veba.yourdomain.com
+...
+```
+```shell
+faas-cli deploy -f stack.yml --tls-no-verify
+```
+

--- a/examples/powercli/hostmaint-alarms/handler/script.ps1
+++ b/examples/powercli/hostmaint-alarms/handler/script.ps1
@@ -1,0 +1,37 @@
+# Process function Secrets passed in
+$VC_CONFIG_FILE = "/var/openfaas/secrets/vcconfig"
+$VC_CONFIG = (Get-Content -Raw -Path $VC_CONFIG_FILE | ConvertFrom-Json)
+if($env:function_debug -eq "true") {
+    Write-host "DEBUG: `"$VC_CONFIG`""
+}
+
+# Process payload sent from vCenter Server Event
+$json = $args | ConvertFrom-Json
+if($env:function_debug -eq "true") {
+    Write-Host "DEBUG: `"$json`""
+}
+
+$eventObjectName = $json.objectName
+$managedObjectReference = $json.managedObjectReference
+
+Set-PowerCLIConfiguration -InvalidCertificateAction Ignore  -DisplayDeprecationWarnings $false -ParticipateInCeip $false -Confirm:$false | Out-Null
+
+# Connect to vCenter Server
+Write-Host "Connecting to vCenter Server ..."
+Connect-VIServer -Server $($VC_CONFIG.VC) -User $($VC_CONFIG.VC_USERNAME) -Password $($VC_CONFIG.VC_PASSWORD)
+
+# Get the vCenter AlarmManager
+$alarmManager = Get-View AlarmManager
+if ($json.topic -eq "entered.maintenance.mode") {
+    # Disable alarm actions on the host
+    Write-Host "Disabling alarm actions on host: $eventObjectName"
+    $alarmManager.EnableAlarmActions($managedObjectReference, $false)
+}
+else {
+    # Enable alarm actions on the host
+    Write-Host "Enabling alarm actions on host: $eventObjectName"
+    $alarmManager.EnableAlarmActions($managedObjectReference, $true)
+}
+
+Write-Host "Disconnecting from vCenter Server ..."
+Disconnect-VIServer * -Confirm:$false

--- a/examples/powercli/hostmaint-alarms/stack.yml
+++ b/examples/powercli/hostmaint-alarms/stack.yml
@@ -1,0 +1,29 @@
+version: 1.0
+provider:
+  name: faas
+  gateway: https://veba.yourdomain.com
+functions:
+  powercli-entermaint:
+    lang: powercli
+    handler: ./handler
+    image: doogleit/powercli-hostmaint:latest
+    environment:
+      write_debug: true
+      read_debug: true
+      function_debug: false
+    secrets:
+      - vcconfig
+    annotations:
+      topic: entered.maintenance.mode
+  powercli-exitmaint:
+    lang: powercli
+    handler: ./handler
+    image: doogleit/powercli-hostmaint:latest
+    environment:
+      write_debug: true
+      read_debug: true
+      function_debug: false
+    secrets:
+      - vcconfig
+    annotations:
+      topic: exit.maintenance.mode

--- a/examples/powercli/hostmaint-alarms/template/powercli/Dockerfile
+++ b/examples/powercli/hostmaint-alarms/template/powercli/Dockerfile
@@ -1,0 +1,26 @@
+FROM vmware/powerclicore:latest
+
+RUN mkdir -p /home/app
+USER root
+RUN echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && cp /usr/bin/fwatchdog /root
+
+
+
+WORKDIR /root
+
+USER root
+
+# Populate example here - i.e. "cat", "sha512sum" or "node index.js"
+SHELL [ "pwsh", "-command" ]
+ENV fprocess="xargs pwsh ./function/script.ps1"
+COPY function function
+# Set to true to see request in function logs
+ENV write_debug="true"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+CMD [ "fwatchdog" ]

--- a/examples/powercli/hostmaint-alarms/template/powercli/function/script.ps1
+++ b/examples/powercli/hostmaint-alarms/template/powercli/function/script.ps1
@@ -1,0 +1,2 @@
+Set-PowerCLIConfiguration -InvalidCertificateAction Ignore  -DisplayDeprecationWarnings $false -ParticipateInCeip $false -Confirm:$false
+write-host "write your powercli code here"

--- a/examples/powercli/hostmaint-alarms/template/powercli/template.yml
+++ b/examples/powercli/hostmaint-alarms/template/powercli/template.yml
@@ -1,0 +1,3 @@
+language: powercli
+fprocess: xargs pwsh ./function/script.ps1
+

--- a/examples/powercli/hostmaint-alarms/vcconfig.json
+++ b/examples/powercli/hostmaint-alarms/vcconfig.json
@@ -1,0 +1,5 @@
+{
+    "VC" : "vcenter-hostname",
+    "VC_USERNAME" : "veba@vsphere.local",
+    "VC_PASSWORD" : "FillMeIn"
+}


### PR DESCRIPTION
This example disables alarms when a host is put in maintenance and re-enables alarms when it exits maintenance.
Signed-off-by: Doug Taliaferro <dougt42@gmail.com>