### PR TITLE
Update depreciated use of "faas" provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The vCenter Event Broker Appliance follows a highly modular approach, using Kube
 - Kubernetes ([Github](https://github.com/kubernetes/kubernetes))
 - Contour ([Github](https://github.com/projectcontour/contour))
 - OpenFaaS ([Website](https://www.openfaas.com/))
-- vCenter Connector ([Github](https://github.com/openfaas-incubator/vcenter-connector/))
+- OpenFaaS vcenter-connector ([Github](https://github.com/openfaas-incubator/vcenter-connector/))
 
 <center><div style="height:250px;width:250px"><img src="veba-appliance-diagram.png" /></div></center>
 

--- a/examples/powercli/hostmaint-alarms/README.md
+++ b/examples/powercli/hostmaint-alarms/README.md
@@ -21,7 +21,7 @@ faas-cli secret create vcconfig --from-file=vcconfig.json --tls-no-verify
 2. Update the gateway in the stack.yml file with your vCenter Event Broker Appliance address and deploy the functions.
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.yourdomain.com
 ...
 ```

--- a/examples/powercli/hostmaint-alarms/stack.yml
+++ b/examples/powercli/hostmaint-alarms/stack.yml
@@ -1,6 +1,6 @@
 version: 1.0
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.yourdomain.com
 functions:
   powercli-entermaint:

--- a/examples/powercli/hwchange-slack/README.md
+++ b/examples/powercli/hwchange-slack/README.md
@@ -22,7 +22,7 @@ Step 2 - Update `stack.yml` and `vcconfig.json` with your enviornment informatio
 
 ```
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.mynetwork.local
 functions:
   powercli-reconfigure:

--- a/examples/powercli/hwchange-slack/stack.yml
+++ b/examples/powercli/hwchange-slack/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.mynetwork.local
 functions:
   powercli-reconfigure:

--- a/examples/powercli/tagging/stack.yml
+++ b/examples/powercli/tagging/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.primp-industries.com
 functions:
   powercli-tag:

--- a/examples/python/tagging/README.MD
+++ b/examples/python/tagging/README.MD
@@ -64,7 +64,7 @@ Lastly, define the vCenter event which will trigger this function. Such function
 
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: https://VEBA_FQDN_OR_IP # replace with your VEBA environment
 functions:
   pytag-fn:

--- a/examples/python/tagging/stack.yml
+++ b/examples/python/tagging/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 functions:
   pytag-fn:

--- a/getting-started.md
+++ b/getting-started.md
@@ -139,7 +139,7 @@ Lastly, define the vCenter event which will trigger this function. Such function
 
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: https://VEBA_FQDN_OR_IP # replace with your VEBA environment
 functions:
   pytag-fn:


### PR DESCRIPTION
The provider name "faas" was depreciated 8 months ago and in
its place "openfaas" should be used. The vcenter-connector link
also needed to be updated in its description to match its name
upstream.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>