### PR TITLE
Fixes to documentation and sample config files for openfaas

### DIFF
--- a/examples/powercli/hostmaint-alarms/README.md
+++ b/examples/powercli/hostmaint-alarms/README.md
@@ -23,7 +23,7 @@ faas-cli secret create vcconfig --from-file=vcconfig.json --tls-no-verify
 2. Update the gateway in the stack.yml file with your vCenter Event Broker Appliance address and deploy the functions.
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.yourdomain.com
 ...
 ```

--- a/examples/powercli/hostmaint-alarms/stack.yml
+++ b/examples/powercli/hostmaint-alarms/stack.yml
@@ -1,6 +1,6 @@
 version: 1.0
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.yourdomain.com
 functions:
   powercli-entermaint:

--- a/examples/powercli/hwchange-slack/README.md
+++ b/examples/powercli/hwchange-slack/README.md
@@ -22,7 +22,7 @@ Step 2 - Update `stack.yml` and `vcconfig.json` with your enviornment informatio
 
 ```
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.mynetwork.local
 functions:
   powercli-reconfigure:

--- a/examples/powercli/hwchange-slack/stack.yml
+++ b/examples/powercli/hwchange-slack/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.mynetwork.local
 functions:
   powercli-reconfigure:

--- a/examples/powercli/tagging/stack.yml
+++ b/examples/powercli/tagging/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: https://veba.primp-industries.com
 functions:
   powercli-tag:

--- a/examples/python/tagging/README.MD
+++ b/examples/python/tagging/README.MD
@@ -64,7 +64,7 @@ Lastly, define the vCenter event which will trigger this function. Such function
 
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: https://VEBA_FQDN_OR_IP # replace with your vCenter Event Broker Appliance environment
 functions:
   pytag-fn:
@@ -88,7 +88,7 @@ After you've performed the steps and modifications above, you can go ahead and d
 
 ```bash
 faas-cli template pull # only required during the first deployment
-faas deploy -f stack.yml --tls-no-verify
+faas-cli deploy -f stack.yml --tls-no-verify
 Deployed. 202 Accepted.
 ```
 

--- a/examples/python/tagging/stack.yml
+++ b/examples/python/tagging/stack.yml
@@ -1,6 +1,6 @@
 provider:
-  name: faas
-  gateway: http://127.0.0.1:8080
+  name: openfaas
+  gateway: https://veba.yourdomain.com
 functions:
   pytag-fn:
     lang: python3
@@ -8,7 +8,7 @@ functions:
     image: embano1/pytag-fn:0.2
     environment:
       write_debug: true
-      read_debuge: true
+      read_debug: true
     secrets:
       - vcconfig
     annotations:


### PR DESCRIPTION
The default provider name in stack.yml is 'faas', but the function fails to deploy with error "['openfaas'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: faas". Changing the default provider name to 'openfaas' fixes the problem.

The readme has a typo calling the command 'faas' when the command needs to be 'faas-cli'.

Changed the default provider gateway to a clearer placeholder - deploying VEBA out of the box requires HTTPS URL, and is not running on port 8080.

Signed-off-by: Patrick Kremer <pkremer@vmware.com>