### PR TITLE
Add proxy settings to ova

### DIFF
--- a/manual/photon-dev.xml.template
+++ b/manual/photon-dev.xml.template
@@ -34,6 +34,27 @@
             <Label>NTP</Label>
             <Description>NTP Servers (space separated)</Description>
         </Property>
+        <Category>Proxy Settings (optional)</Category>
+        <Property ovf:key="guestinfo.http_proxy" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>HTTP Proxy</Label>
+            <Description>Enter HTTP Proxy Server followed by the port and without typing "http://" before. Example: "proxy.provider.com:3128"</Description>
+        </Property>
+        <Property ovf:key="guestinfo.https_proxy" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>HTTPS Proxy</Label>
+            <Description>Enter HTTPS Proxy Server followed by the port and without typing "https://" before. Example: "proxy.provider.com:3128"</Description>
+        </Property>
+        <Property ovf:key="guestinfo.proxy_username" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>Proxy Username (optional)</Label>
+            <Description>Username for the Proxy Server</Description>
+        </Property>
+        <Property ovf:key="guestinfo.proxy_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>Proxy Password (optional)</Label>
+            <Description>Password for the Proxy User</Description>
+        </Property>
+            <Property ovf:key="guestinfo.no_proxy" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>No Proxy</Label>
+            <Description>No Proxy for e.g. your internal domain suffix. Comma separated (localhost, 127.0.0.1, domain.local)</Description>
+        </Property>
         <Category>Credentials</Category>
         <Property ovf:key="guestinfo.root_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="VMware1!">
             <Label>Root Password</Label>

--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -34,6 +34,27 @@
             <Label>NTP</Label>
             <Description>NTP Servers (space separated)</Description>
         </Property>
+        <Category>Proxy Settings (optional)</Category>
+        <Property ovf:key="guestinfo.http_proxy" ovf:type="string" ovf:userConfigurable="true">
+            <Label>HTTP Proxy</Label>
+            <Description>Enter HTTP Proxy Server followed by the port and without typing "http://" before. Example: "proxy.provider.com:3128"</Description>
+        </Property>
+        <Property ovf:key="guestinfo.https_proxy" ovf:type="string" ovf:userConfigurable="true">
+            <Label>HTTPS Proxy</Label>
+            <Description>Enter HTTPS Proxy Server followed by the port and without typing "https://" before. Example: "proxy.provider.com:3128"</Description>
+        </Property>
+        <Property ovf:key="guestinfo.proxy_username" ovf:type="string" ovf:userConfigurable="true">
+            <Label>Proxy Username (optional)</Label>
+            <Description>Username for the Proxy Server</Description>
+        </Property>
+        <Property ovf:key="guestinfo.proxy_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+            <Label>Proxy Password (optional)</Label>
+            <Description>Password for the Proxy User</Description>
+        </Property>
+        <Property ovf:key="guestinfo.no_proxy" ovf:type="string" ovf:userConfigurable="true">
+            <Label>No Proxy</Label>
+            <Description>No Proxy for e.g. your internal domain suffix. Comma separated (localhost, 127.0.0.1, domain.local)</Description>
+        </Property>
         <Category>Credentials</Category>
         <Property ovf:key="guestinfo.root_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
             <Label>Root Password</Label>

--- a/photon-dev.json
+++ b/photon-dev.json
@@ -14,6 +14,11 @@
     "ovftool_deploy_vm_dns": "192.168.30.1",
     "ovftool_deploy_vm_dns_domain": "primp-industries.com",
     "ovftool_deploy_vm_ntp": "pool.ntp.org",
+    "ovftool_deploy_vm_http_proxy": "",
+    "ovftool_deploy_vm_https_proxy": "",
+    "ovftool_deploy_vm_proxy_username": "",
+    "ovftool_deploy_vm_proxy_password": "",
+    "ovftool_deploy_vm_no_proxy": "",
     "ovftool_deploy_vm_root_password": "VMware1!",
     "ovftool_deploy_vm_openfaas_password": "VMware1!",
     "ovftool_deploy_vm_vcenter_server": "192.168.30.200",
@@ -135,7 +140,7 @@
     {
       "type": "shell-local",
       "inline": [
-        "ovftool --powerOn --name={{ user `ovftool_deploy_vm_name` }} --net:'VM Network={{ user `ovftool_deploy_vm_network` }}' --datastore={{ user `ovftool_deploy_vm_datastore` }} --prop:guestinfo.hostname={{ user `ovftool_deploy_vm_hostname` }} --prop:guestinfo.ipaddress={{ user `ovftool_deploy_vm_ip_address` }} --prop:guestinfo.netmask={{ user `ovftool_deploy_vm_prefix` }} --prop:guestinfo.gateway={{ user `ovftool_deploy_vm_gateway` }} --prop:guestinfo.dns={{ user `ovftool_deploy_vm_dns` }} --prop:guestinfo.domain={{ user `ovftool_deploy_vm_dns_domain` }} --prop:guestinfo.ntp={{ user `ovftool_deploy_vm_ntp` }} --prop:guestinfo.root_password={{ user `vm_ovftool_deploy_root_password` }} --prop:guestinfo.openfaas_password={{ user `ovftool_deploy_vm_openfaas_password` }} --prop:guestinfo.vcenter_server={{ user `ovftool_deploy_vm_vcenter_server` }} --prop:guestinfo.vcenter_username={{ user `ovftool_deploy_vm_vcenter_username` }} --prop:guestinfo.vcenter_password={{ user `ovftool_deploy_vm_vcenter_password` }} --prop:guestinfo.vcenter_disable_tls_verification=True --prop:guestinfo.pod_network_cidr={{ user `ovftool_deploy_vm_pod_network_cidr` }} --prop:guestinfo.debug=True output-vmware-iso/{{ user `vm_name` }}_{{user `version`}}.ova 'vi://{{ user `ovftool_deploy_vcenter_username` }}:{{ user `ovftool_deploy_vcenter_password` }}@{{ user `ovftool_deploy_vcenter` }}/{{ user `ovftool_deploy_datacenter` }}/host/{{ user `ovftool_deploy_cluster` }}/'"
+        "ovftool --powerOn --name={{ user `ovftool_deploy_vm_name` }} --net:'VM Network={{ user `ovftool_deploy_vm_network` }}' --datastore={{ user `ovftool_deploy_vm_datastore` }} --prop:guestinfo.hostname={{ user `ovftool_deploy_vm_hostname` }} --prop:guestinfo.ipaddress={{ user `ovftool_deploy_vm_ip_address` }} --prop:guestinfo.netmask={{ user `ovftool_deploy_vm_prefix` }} --prop:guestinfo.gateway={{ user `ovftool_deploy_vm_gateway` }} --prop:guestinfo.dns={{ user `ovftool_deploy_vm_dns` }} --prop:guestinfo.domain={{ user `ovftool_deploy_vm_dns_domain` }} --prop:guestinfo.ntp={{ user `ovftool_deploy_vm_ntp` }} --prop:guestinfo.http_proxy={{ user `ovftool_deploy_vm_http_proxy` }} --prop:guestinfo.https_proxy={{ user `ovftool_deploy_vm_https_proxy` }} --prop:guestinfo.proxy_username={{ user `ovftool_deploy_vm_proxy_username` }} --prop:guestinfo.proxy_password={{ user `ovftool_deploy_vm_proxy_password` }} --prop:guestinfo.no_proxy={{ user `ovftool_deploy_vm_no_proxy` }} --prop:guestinfo.root_password={{ user `vm_ovftool_deploy_root_password` }} --prop:guestinfo.openfaas_password={{ user `ovftool_deploy_vm_openfaas_password` }} --prop:guestinfo.vcenter_server={{ user `ovftool_deploy_vm_vcenter_server` }} --prop:guestinfo.vcenter_username={{ user `ovftool_deploy_vm_vcenter_username` }} --prop:guestinfo.vcenter_password={{ user `ovftool_deploy_vm_vcenter_password` }} --prop:guestinfo.vcenter_disable_tls_verification=True --prop:guestinfo.pod_network_cidr={{ user `ovftool_deploy_vm_pod_network_cidr` }} --prop:guestinfo.debug=True output-vmware-iso/{{ user `vm_name` }}_{{user `version`}}.ova 'vi://{{ user `ovftool_deploy_vcenter_username` }}:{{ user `ovftool_deploy_vcenter_password` }}@{{ user `ovftool_deploy_vcenter` }}/{{ user `ovftool_deploy_datacenter` }}/host/{{ user `ovftool_deploy_cluster` }}/'"
       ]
     },
     {


### PR DESCRIPTION
Signed-off-by: Robert Guske <rguske@vmware.com>

Fixes #40 
  
Provides proxy settings to enable the provisioning of VEBA in environments that allows Internet connection through a proxy only. It is also necessary for functions that require an outgoing connection in such environments.
- [x] changes implemented
- [x] tested 
- validation that the provision of VEBA behind a proxy is successful

![image](https://user-images.githubusercontent.com/31652019/71851010-db156080-30d5-11ea-935c-78b4c7ddf69f.png)
![image](https://user-images.githubusercontent.com/31652019/71851857-c6d26300-30d7-11ea-8885-9c729cd8fc59.png)

