### PR TITLE
Add ntp settings to ova

### DIFF
--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -30,6 +30,10 @@
             <Label>DNS Domain</Label>
             <Description>DNS Domain</Description>
         </Property>
+        <Property ovf:key="guestinfo.ntp" ovf:type="string" ovf:userConfigurable="true">
+            <Label>NTP</Label>
+            <Description>NTP Servers (space separated)</Description>
+        </Property>
         <Category>Credentials</Category>
         <Property ovf:key="guestinfo.root_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
             <Label>Root Password</Label>


### PR DESCRIPTION
Signed-off-by: Robert Guske <rguske@vmware.com>

PR fixes #30 
Allows to add NTP server(s).

- [x] changes implemented
- [x] tested

- Checked that the servers entered in the ova setup have been successfully configured as _SystemNTPServers_

![image](https://user-images.githubusercontent.com/31652019/71897838-fde85900-3157-11ea-93a7-6ef1a978233b.png)
![image](https://user-images.githubusercontent.com/31652019/71898270-2cb2ff00-3159-11ea-8cba-980476dfce6d.png)
![image](https://user-images.githubusercontent.com/31652019/71897808-eb6e1f80-3157-11ea-8e9a-c10889686b4c.png)
