### PR TITLE
replace references of [IP] to [hostname]

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -40,14 +40,14 @@
 **Step 3** - Power On the vCenter Event Broker Appliance after successful deployment. Depending on your external network connectivity, it can take a few minutes while the system is being setup. You can open the VM Console to view the progress. Once everything is completed, you should see an updated login banner for the various endpoints:
 
 ```
-Appliance Status: https://[IP]/status
-Install Logs: https://[IP]/bootstrap
-OpenFaaS UI: https://[IP]
+Appliance Status: https://[hostname]/status
+Install Logs: https://[hostname]/bootstrap
+OpenFaaS UI: https://[hostname]
 ```
 
 **Note**: If you enable Debugging, the install logs endpoint will automatically contain the more verbose log entries.
 
-**Step 4** - You can verify that everything was deployed correctly by opening a web browser to the OpenFaaS UI and logging in with the Admin credentials (user:admin) you had specified as part of the OVA deployment.
+**Step 4** - You can verify that everything was deployed correctly by opening a web browser to the OpenFaaS UI available on https://[hostname]/ and logging in with the Admin credentials (user:admin) you had specified as part of the OVA deployment.
 
 At this point, you have successfully deployed the vCenter Event Broker Appliance and you are ready to start deploying your functions!
 

--- a/scripts/photon-openfaas.sh
+++ b/scripts/photon-openfaas.sh
@@ -30,9 +30,9 @@ cd ..
 cat << EOF > /etc/issue
 Welcome to the vCenter Event Broker Appliance
 
-Appliance Status: https://[IP]/status
-Install Logs: https://[IP]/bootstrap
-OpenFaaS UI: https://[IP]
+Appliance Status: https://[hostname]/status
+Install Logs: https://[hostname]/bootstrap
+OpenFaaS UI: https://[hostname]
 
 
 EOF


### PR DESCRIPTION
The docs and /etc/issue of the VM (visible on the console) talk about going to [IP] to see the OpenFaaS UI, but actually it's the hostname that's needed due to the following IngressRoute, where fqdn=hostname:
```

apiVersion: contour.heptio.com/v1beta1
kind: IngressRoute
metadata:
  labels:
    app: openfaas
  name: ingressroute-gateway
  namespace: openfaas
spec:
  virtualhost:
    fqdn: xxx
    tls:
      secretName: openfaas-gw-tls
      minimumProtocolVersion: "1.2"
  routes:
    - match: /status
      prefixRewrite: /status
      services:
      - name: tinywww
        port: 8100
    - match: /bootstrap
      prefixRewrite: /bootstrap
      services:
      - name: tinywww
        port: 8100
    - match: /
      services:
      - name: gateway
        port: 8080

```