### PR TITLE
Use ErrorGroup Context to return on first error

### DIFF
--- a/vmware-event-router/cmd/main.go
+++ b/vmware-event-router/cmd/main.go
@@ -141,14 +141,14 @@ func main() {
 		time.Sleep(3 * time.Second)
 	}()
 
-	eg := errgroup.Group{}
+	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return metricsServer.Run(ctx, bindAddr)
+		return metricsServer.Run(egCtx, bindAddr)
 	})
 
 	eg.Go(func() error {
-		defer streamer.Shutdown(ctx)
-		return streamer.Stream(ctx, proc)
+		defer streamer.Shutdown(egCtx)
+		return streamer.Stream(egCtx, proc)
 	})
 
 	// blocks

--- a/vmware-event-router/internal/metrics/server.go
+++ b/vmware-event-router/internal/metrics/server.go
@@ -73,6 +73,7 @@ func NewServer(cfg connection.Config) (*Server, error) {
 // occurs. It will collect metrics for the given event streams and processors.
 func (s *Server) Run(ctx context.Context, bindAddr string) error {
 	errCh := make(chan error, 1)
+	defer close(errCh)
 	go func() {
 		addr := fmt.Sprintf("http://%s%s", bindAddr, endpoint)
 		s.Printf("starting metrics server and listening on %q", addr)


### PR DESCRIPTION
Fix a bug where http server would err but `errGrp.Wait()` waits for **all** Goroutines to finish.

Signed-off-by: Michael Gasch <mgasch@vmware.com>