### PR TITLE
Add branch information to Python examples

### DIFF
--- a/examples/python/esx-mtu-fixer/README.md
+++ b/examples/python/esx-mtu-fixer/README.md
@@ -2,9 +2,19 @@
 
 This is a remediation function which will be triggered when a VM is powered on. It will make sure that the Maximum Transmission Unit (MTU) of the VM Kernel Adapter on all ESX hosts is at least `1500`. You can find out more about why `1500` is an optimal value in the [wikipedia page](https://en.wikipedia.org/wiki/Maximum_transmission_unit).
 
+## Get the example function
+
+Clone this repository which contains the example functions. 
+
+```bash
+git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
+cd vcenter-event-broker-appliance/examples/python/esx-mtu-fixer
+git checkout master
+```
+
 ## Set up
 
-The function needs credentials and endpoint of the vCenter with which the function will interact. You can see how to create a secret containing those credentials in your kubernetes cluster in the [create_secret](./create_secret.sh) script. Your `kubectl` must be configured to communicate with your remote cluster first.
+The function needs credentials and endpoint of the vCenter with which the function will interact. You can see how to create a secret containing those credentials in your Kubernetes cluster in the [create_secret](./create_secret.sh) script. Your `kubectl` must be configured to communicate with your remote cluster first.
 
 ## Deploy the function
 

--- a/examples/python/tagging/README.MD
+++ b/examples/python/tagging/README.MD
@@ -5,6 +5,7 @@ Clone this repository which contains the example functions.
 ```bash
 git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
 cd vcenter-event-broker-appliance/examples/python/tagging
+git checkout master
 ```
 
 ### Categories and tags


### PR DESCRIPTION
Examples run by users should always be run from `master` instead of `development` (default).

Signed-off-by: Michael Gasch <mgasch@vmware.com>