### PR TITLE
Stricter linting on VMware Event Router

### DIFF
--- a/vmware-event-router/Dockerfile
+++ b/vmware-event-router/Dockerfile
@@ -5,12 +5,17 @@ ARG COMMIT
 
 WORKDIR /build
 
+# install linter into ./bin/
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.23.7
+
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
 COPY cmd cmd
 COPY internal internal
+
+RUN ./bin/golangci-lint run ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT}" -o vmware-event-router cmd/main.go
 
 # debian:stable-slim

--- a/vmware-event-router/Makefile
+++ b/vmware-event-router/Makefile
@@ -31,9 +31,9 @@ tidy:
 	$(info Make: syncing and cleaning up Go dependencies.)
 	go mod tidy -v
 
+# intended for local dev use (won't check for unclean git)
 binary: test tidy
 	$(info Make: Building binary "$(DIST_FOLDER)/$(BINARY)".)
-	$(if $(GIT_NOT_CLEAN_CHECK), $(error "Dirty Git repository."))
 	CGO_ENABLED=0 go build -a -installsuffix nocgo -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT}" -o $(DIST_FOLDER)/$(BINARY) cmd/main.go
 
 build: test tidy


### PR DESCRIPTION
- Use stricter linting during Docker build/release
- For local testing linting and clean Git dir is not enforced though

Signed-off-by: Michael Gasch <mgasch@vmware.com>