### PR TITLE
Fix linter errors

### DIFF
--- a/vmware-event-router/internal/stream/vcenter.go
+++ b/vmware-event-router/internal/stream/vcenter.go
@@ -104,11 +104,13 @@ func (vcenter *vCenterStream) Source() string {
 }
 
 func (vcenter *vCenterStream) PushMetrics(ctx context.Context, ms *metrics.Server) {
+	ticker := time.NewTicker(metrics.PushInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.Tick(metrics.PushInterval):
+		case <-ticker.C:
 			vcenter.lock.RLock()
 			eventsSec := math.Round((float64(*vcenter.stats.EventsTotal)/time.Since(vcenter.stats.Started).Seconds())*100) / 100 // 0.2f syntax
 			vcenter.stats.EventsSec = &eventsSec


### PR DESCRIPTION
Fixes linter errors regression introduced in #58

Closes: #60 

Tested via:

```bash
make

[...]

Step 24/24 : ENTRYPOINT ["./vmware-event-router"]
 ---> Using cache
  ---> 5c4aa02006a4
  Successfully built 5c4aa02006a4
  Successfully tagged vmware/veba-event-router:e54fee2
```

Tested the new build successfully against OpenFaaS and AWS EventBridge
with a VmPoweredOffEvent.

Signed-off-by: Michael Gasch <mgasch@vmware.com>