### PR TITLE
Fix Host MoRef processing for PCLI Host Maintenance Function

### DIFF
--- a/examples/powercli/hostmaint-alarms/README.md
+++ b/examples/powercli/hostmaint-alarms/README.md
@@ -2,8 +2,7 @@
 
 ## Description
 
-This example will disable alarm actions on a host while it is in maintenance mode.  It deploys two functions that use the same PowerCLI script.  The first function subscribes to the `entered.maintenance.mode` event to run when a host is put into maintenance mode and disable alarms.  The second function subscribes to the `exit.maintenance.mode` event to re-enable alarms when the host exits maintenance mode.  There is an accompanying blog post with more details:  [Automate Host Maintenance with the vCenter Event Broker Appliance
-](https://doogleit.github.io/2019/11/automate-host-maintenance-with-the-vcenter-event-broker-appliance/)
+This example will disable alarm actions on a host when it has entered maintenance mode and will re-enable alarm actions on a host after it has exited maintenance mode. There is an accompanying blog post with more details:  [Automate Host Maintenance with the vCenter Event Broker Appliance](https://doogleit.github.io/2019/11/automate-host-maintenance-with-the-vcenter-event-broker-appliance/)
 
 ## Consume Function Instruction
 

--- a/examples/powercli/hostmaint-alarms/stack.yml
+++ b/examples/powercli/hostmaint-alarms/stack.yml
@@ -14,16 +14,4 @@ functions:
     secrets:
       - vc-hostmaint-config
     annotations:
-      topic: EnteredMaintenanceModeEvent
-  powercli-exitmaint:
-    lang: powercli
-    handler: ./handler
-    image: vmware/veba-powercli-esx-maintenance:latest
-    environment:
-      write_debug: true
-      read_debug: true
-      function_debug: false
-    secrets:
-      - vc-hostmaint-config
-    annotations:
-      topic: ExitMaintenanceModeEvent
+      topic: EnteredMaintenanceModeEvent, ExitMaintenanceModeEvent


### PR DESCRIPTION
@kremerpatrick found the initial v0.3 sample did not properly process the MoRef IDs for ESXi host, this PR fixes that sample. Patrick has also validated the function changes in his own environment to ensure things are working and the updated docker container has also been pushed. 

Signed-off-by: William Lam <wlam@vmware.com>