### PR TITLE
Add support for colorized log output

### DIFF
--- a/vmware-event-router/cmd/main.go
+++ b/vmware-event-router/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/color"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/connection"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/metrics"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/processor"
@@ -33,7 +34,7 @@ var banner = `
 
 func main() {
 	fmt.Println(banner)
-	var logger = log.New(os.Stdout, "[VMware Event Router] ", log.LstdFlags)
+	var logger = log.New(os.Stdout, color.Green("[VMware Event Router] "), log.LstdFlags)
 
 	var configPath string
 	var verbose bool

--- a/vmware-event-router/internal/color/color.go
+++ b/vmware-event-router/internal/color/color.go
@@ -1,0 +1,28 @@
+package color
+
+import "fmt"
+
+var (
+	Info = Teal
+	Warn = Yellow
+	Fata = Red
+)
+
+var (
+	Black   = Color("\033[1;30m%s\033[0m")
+	Red     = Color("\033[1;31m%s\033[0m")
+	Green   = Color("\033[1;32m%s\033[0m")
+	Yellow  = Color("\033[1;33m%s\033[0m")
+	Purple  = Color("\033[1;34m%s\033[0m")
+	Magenta = Color("\033[1;35m%s\033[0m")
+	Teal    = Color("\033[1;36m%s\033[0m")
+	White   = Color("\033[1;37m%s\033[0m")
+)
+
+func Color(colorString string) func(...interface{}) string {
+	sprint := func(args ...interface{}) string {
+		return fmt.Sprintf(colorString,
+			fmt.Sprint(args...))
+	}
+	return sprint
+}

--- a/vmware-event-router/internal/metrics/server.go
+++ b/vmware-event-router/internal/metrics/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/color"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/connection"
 )
 
@@ -48,7 +49,7 @@ func NewServer(cfg connection.Config) (*Server, error) {
 		return nil, errors.Errorf("unsupported authentication method for metrics server: %q", cfg.Auth.Method)
 	}
 
-	logger := log.New(os.Stdout, "[Metrics Server] ", log.LstdFlags)
+	logger := log.New(os.Stdout, color.Teal("[Metrics Server] "), log.LstdFlags)
 	mux := http.NewServeMux()
 	switch basicAuth {
 	case true:

--- a/vmware-event-router/internal/processor/aws_event_bridge.go
+++ b/vmware-event-router/internal/processor/aws_event_bridge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/pkg/errors"
+	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/color"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/connection"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/events"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/metrics"
@@ -50,7 +51,7 @@ type eventPattern struct {
 // NewAWSEventBridgeProcessor returns an AWS EventBridge processor for the given
 // stream source.
 func NewAWSEventBridgeProcessor(ctx context.Context, cfg connection.Config, source string, verbose bool, ms *metrics.Server) (Processor, error) {
-	logger := log.New(os.Stdout, "[AWS EventBridge] ", log.LstdFlags)
+	logger := log.New(os.Stdout, color.Yellow("[AWS EventBridge] "), log.LstdFlags)
 	eventBridge := awsEventBridgeProcessor{
 		source:     source,
 		verbose:    verbose,

--- a/vmware-event-router/internal/processor/openfaas.go
+++ b/vmware-event-router/internal/processor/openfaas.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/openfaas-incubator/connector-sdk/types"
 	"github.com/openfaas/faas-provider/auth"
 	"github.com/pkg/errors"
+	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/color"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/connection"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/events"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/metrics"
@@ -43,7 +44,7 @@ type openfaasProcessor struct {
 // source. Asynchronous function invokation can be configured for
 // high-throughput (non-blocking) requirements.
 func NewOpenFaaSProcessor(ctx context.Context, cfg connection.Config, source string, verbose bool, ms *metrics.Server) (Processor, error) {
-	logger := log.New(os.Stdout, "[OpenFaaS] ", log.LstdFlags)
+	logger := log.New(os.Stdout, color.Purple("[OpenFaaS] "), log.LstdFlags)
 	openfaas := openfaasProcessor{
 		source:  source,
 		verbose: verbose,


### PR DESCRIPTION
Add support for colorized log output for better readability/troubleshooting.

![image](https://user-images.githubusercontent.com/15986659/75867858-83f6e800-5e07-11ea-9c99-aaee5260b8c9.png)


Signed-off-by: Michael Gasch <mgasch@vmware.com>