### PR TITLE
Ensuring eth0 interface is shown first in vSphere UI

### DIFF
--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -29,4 +29,14 @@ tdnf install -y \
 echo '> Creating directory for setup scripts'
 mkdir -p /root/setup
 
+echo '> Creating tools.conf to prioritize eth0 interface...'
+cat /etc/vmware-tools/tools.conf << EOF
+[guestinfo]
+primary-nics=eth0
+low-priority-nics=weave,docker0
+
+[guestinfo]
+exclude-nics=veth*,vxlan*,datapath
+EOF
+
 echo '> Done'


### PR DESCRIPTION
This is to resolve https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/65 

Validation:
- Deployed tools.conf configuration and ensure eth0 is listed first and then followed by either weave/docker0 for secondary interfaces. Hiding veth*, vxlan* and datapath interfaces by default as these aren't important to show in the vSphere UI

<img width="767" alt="Screen Shot 2020-03-04 at 12 46 24 PM" src="https://user-images.githubusercontent.com/602199/75921572-2f0e9e00-5e16-11ea-9bca-e259b1dd2920.png">

Signed-off-by: William Lam <wlam@vmware.com>