### PR TITLE
Added unauthenticated SMTP and green status emails

### DIFF
--- a/examples/powercli/datastore-usage-email/README.md
+++ b/examples/powercli/datastore-usage-email/README.md
@@ -15,6 +15,7 @@ git checkout master
 ```
 
 Step 2 - Update `stack.yml` and `vc-datastore-config.json` with your environment information
+Note: leave SMTP_USERNAME and SMTP_PASSWORD blank if you do not want to use authenticated SMTP
 
 Step 3 - Login to the OpenFaaS gateway on vCenter Event Broker Appliance
 

--- a/examples/powercli/datastore-usage-email/README.md
+++ b/examples/powercli/datastore-usage-email/README.md
@@ -15,7 +15,8 @@ git checkout master
 ```
 
 Step 2 - Update `stack.yml` and `vc-datastore-config.json` with your environment information
-Note: leave SMTP_USERNAME and SMTP_PASSWORD blank if you do not want to use authenticated SMTP
+
+<B>Note:</B> leave SMTP_USERNAME and SMTP_PASSWORD blank if you do not want to use authenticated SMTP
 
 Step 3 - Login to the OpenFaaS gateway on vCenter Event Broker Appliance
 

--- a/examples/powercli/datastore-usage-email/handler/script.ps1
+++ b/examples/powercli/datastore-usage-email/handler/script.ps1
@@ -24,7 +24,7 @@ if($env:function_debug -eq "true") {
     Write-Host "DEBUG: vcenter: `"$vcenter`""
 }
 
-if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.DATASTORE_NAMES -match "$datastoreName")) -and ($alarmStatus -eq "yellow" -or $alarmStatus -eq "red") ) {
+if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.DATASTORE_NAMES -match "$datastoreName")) -and ($alarmStatus -eq "yellow" -or $alarmStatus -eq "red" -or $alarmStatus -eq "green") ) {
 
     # Warning Email Body
     if($alarmStatus -eq "yellow") {
@@ -33,22 +33,34 @@ if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.
     } elseif($alarmStatus -eq "red") {
         $subject = "☢️ $($VC_CONFIG.EMAIL_SUBJECT) ☢️ "
         $threshold = "error"
-    }
+    } elseif($alarmStatus -eq "green") {
+        $subject = "$($VC_CONFIG.EMAIL_SUBJECT)"
+        $threshold = "normal"
+	}
 
-    $Body = @"
-        $alarmName $datastoreName has reached $threshold threshold
+    $Body = "$alarmName $datastoreName has reached $threshold threshold.`r`n"
+	
+	if ( $threshold -ne "normal" )
+	{
+		$Body = $Body + "Please log in to your VMware Cloud on AWS environment and ensure that everything is operating as expected.`r`n"
+	}
 
-        Please login to your VMware Cloud on AWS environment and ensure that everything is operating as expected.
-
-        vCenter Server: $vcenter
+	$Body = $Body + @"
+	    vCenter Server: $vcenter
         Datacenter: $datacenter
-        Datastore: $datastoreName
-
+        Datastore: $datastoreName	
 "@
+	if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0)
+	{
+		$password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
+		$credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
+		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
+	}
+	else
+	{
+		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
+	}
 
-    $password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
-    $credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
 
-    Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
 }
 

--- a/examples/powercli/datastore-usage-email/handler/script.ps1
+++ b/examples/powercli/datastore-usage-email/handler/script.ps1
@@ -50,17 +50,12 @@ if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.
         Datacenter: $datacenter
         Datastore: $datastoreName	
 "@
-	if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0)
-	{
+	if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0) {
 		$password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
 		$credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
 		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
+	} else {
+	    Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
 	}
-	else
-	{
-		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
-	}
-
-
 }
 

--- a/examples/powercli/datastore-usage-email/handler/script.ps1
+++ b/examples/powercli/datastore-usage-email/handler/script.ps1
@@ -36,26 +36,25 @@ if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.
     } elseif($alarmStatus -eq "green") {
         $subject = "$($VC_CONFIG.EMAIL_SUBJECT)"
         $threshold = "normal"
-	}
+    }
 
     $Body = "$alarmName $datastoreName has reached $threshold threshold.`r`n"
-	
-	if ( $threshold -ne "normal" )
-	{
-		$Body = $Body + "Please log in to your VMware Cloud on AWS environment and ensure that everything is operating as expected.`r`n"
-	}
+    
+    if ( $threshold -ne "normal" ) {
+        $Body = $Body + "Please log in to your VMware Cloud on AWS environment and ensure that everything is operating as expected.`r`n"
+    }
 
-	$Body = $Body + @"
-	    vCenter Server: $vcenter
+    $Body = $Body + @"
+        vCenter Server: $vcenter
         Datacenter: $datacenter
         Datastore: $datastoreName	
 "@
-	if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0) {
-		$password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
-		$credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
-		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
-	} else {
-	    Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
-	}
+    if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0) {
+        $password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
+        $credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
+        Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
+    } else {
+        Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
+    }
 }
 


### PR DESCRIPTION
Allows SMTP_PASSWORD and SMTP_USERNAME to be blank in the JSON config - if both are blank, unauthenticated SMTP on port 25 will be sent.

Added green alarm status for notification when alarm returns to normal.

Adjusted the email body language to match the alarm status.

Signed-off-by: Patrick Kremer <pkremer@vmware.com>