### PR TITLE
Make EventBridge client interface

### DIFF
--- a/vmware-event-router/internal/processor/aws_event_bridge.go
+++ b/vmware-event-router/internal/processor/aws_event_bridge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface"
 	"github.com/pkg/errors"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/color"
 	"github.com/vmware-samples/vcenter-event-broker-appliance/vmware-event-router/internal/connection"
@@ -32,7 +33,7 @@ const (
 // awsEventBridgeProcessor implements the Processor interface
 type awsEventBridgeProcessor struct {
 	session session.Session
-	eventbridge.EventBridge
+	eventbridgeiface.EventBridgeAPI
 	source  string
 	verbose bool
 	*log.Logger
@@ -100,7 +101,7 @@ func NewAWSEventBridgeProcessor(ctx context.Context, cfg connection.Config, sour
 	if ebSession == nil {
 		return nil, errors.Errorf("could not create AWS event bridge session")
 	}
-	eventBridge.EventBridge = *ebSession
+	eventBridge.EventBridgeAPI = ebSession
 
 	var found bool
 	var nextToken *string


### PR DESCRIPTION
Use interface in the EventBridge processor to enable mocking in unit
tests.

Related issue: #69

Signed-off-by: Michael Gasch <mgasch@vmware.com>