### PR TITLE
Add Github action for stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+  - cron: '*/5 * * * *'
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Marking issue as stale due to no activitiy within the last 60 days (will close in 5 days)'
+        stale-pr-message: 'Marking pull request as stale due to no activitiy within the last 60 days (will close in 5 days)'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 60
+        days-before-close: 5
+        main: 'lib/main.js'


### PR DESCRIPTION
After 60 days of inactivity, mark issues/PRs with label `stale` and
close after 5 days if no response is received (label not removed).

Signed-off-by: Michael Gasch <mgasch@vmware.com>