### PR TITLE
Add /etc/veba-release to include VEBA version, commit ID & event processor

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,15 @@
 echo "Building OVA ..."
 rm -f output-vmware-iso/*.ova
 
+if [[ ! -z $(git status -s) ]]; then
+    echo "Dirty Git repository, please clean up any untracked files or commit them before building"
+    exit
+fi
+
 if [[ "$1" -gt "-1" ]] && [[ $1 == "dev" ]]; then
     echo "Applying packer build to photon-dev.json ..."
     packer build -var-file=photon-builder.json -var-file=photon-version.json photon-dev.json
 else
     echo "Applying packer build to photon.json ..."
-    packer build -var-file=photon-builder.json -var-file=photon-version.json photon.json
+    packer build -var "VEBA_VERSION=$(cat VERSION)" -var "VEBA_COMMIT=$(git rev-parse --short HEAD)" -var-file=photon-builder.json -var-file=photon-version.json photon.json
 fi

--- a/files/setup-05-event-processor.sh
+++ b/files/setup-05-event-processor.sh
@@ -64,6 +64,7 @@ if [ "${EVENT_PROCESSOR_TYPE}" == "AWS EventBridge" ]; then
 	}
 ]
 __AWS_EVENTBRIDGE_PROCESSOR__
+echo "Processor: EventBridge" >> /etc/veba-release
 else
     # Setup OpenFaaS
     echo -e "\e[92mSetting up OpenFaas Processor ..." > /dev/console
@@ -121,4 +122,5 @@ else
 	}
 ]
 __OPENFAAS_PROCESSOR__
+echo "Processor: OpenFaaS" >> /etc/veba-release
 fi

--- a/photon.json
+++ b/photon.json
@@ -51,6 +51,10 @@
   "provisioners": [
     {
       "type": "shell",
+      "environment_vars": [
+        "VEBA_VERSION={{ user `VEBA_VERSION` }}",
+        "VEBA_COMMIT={{ user `VEBA_COMMIT` }}"
+      ],
       "expect_disconnect" : true,
       "scripts": [
         "scripts/photon-settings.sh",

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -39,4 +39,9 @@ low-priority-nics=weave,docker0
 exclude-nics=veth*,vxlan*,datapath
 EOF
 
+cat > /etc/veba-release << EOF
+Version: ${VEBA_VERSION}
+Commit: ${VEBA_COMMIT}
+EOF
+
 echo '> Done'

--- a/test/deploy_veba_eventbridge_processor.sh
+++ b/test/deploy_veba_eventbridge_processor.sh
@@ -5,7 +5,7 @@
 # Sample Shell Script to test deployment of VEBA w/AWS EventBridge Processor
 
 OVFTOOL_BIN_PATH="/Applications/VMware OVF Tool/ovftool"
-VEBA_OVA="../output-vmware-iso/vCenter_Event_Broker_Appliance_0.3.0.ova"
+VEBA_OVA="../output-vmware-iso/vCenter_Event_Broker_Appliance_0.4.0-beta.ova"
 
 # vCenter
 DEPLOYMENT_TARGET_ADDRESS="192.168.30.200"


### PR DESCRIPTION
Closing https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/91

Version/Commit ID is generated from the build.sh script and passes that into Packer as environmental variables which is then used to construct the initial `/etc/veba-release` file. Upon first boot after a user configures VEBA, the processor type is appended to the file. 

Testing was done on both OpenFaaS and AWS Event Bridge and below are the outputs when cat'ing `/etc/veba-release`

```
# cat /etc/veba-release
Version: v0.3.0
Commit: 634263b
Processor: OpenFaaS
```

```
# cat /etc/veba-release
Version: v0.3.0
Commit: 634263b
Processor: EventBridge
```

Signed-off-by: William Lam <wlam@vmware.com>