### PR TITLE
Pull Weave YAML from Git repo versus dynamic URL

### DIFF
--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: BSD-2
 
 echo '> Downloading weave.yaml'
-curl -L https://cloud.weave.works/k8s/net?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxNCIsIEdpdFZlcnNpb246InYxLjE0LjYiLCBHaXRDb21taXQ6Ijk2ZmFjNWNkMTNhNWRjMDY0ZjdkOWY0ZjIzMDMwYTZhZWZhY2U2Y2MiLCBHaXRUcmVlU3RhdGU6ImFyY2hpdmUiLCBCdWlsZERhdGU6IjIwMTktMTAtMzFUMDY6MDQ6MDNaIiwgR29WZXJzaW9uOiJnbzEuMTMuMyIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTQiLCBHaXRWZXJzaW9uOiJ2MS4xNC45IiwgR2l0Q29tbWl0OiI1MDBmNWFiYTgwZDcxMjUzY2MwMWFjNmE4NjIyYjgzNzdmNGE3ZWY5IiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAxOS0xMS0xM1QxMToxMzowNFoiLCBHb1ZlcnNpb246ImdvMS4xMi4xMiIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9Cg -o /root/config/weave.yaml
-sed -i '/^          hostNetwork:.*/i \              imagePullPolicy: IfNotPresent' /root/config/weave.yaml
+curl -L https://raw.githubusercontent.com/weaveworks/weave/9f00f78d3b9d5a8a31fdd90ec691095028e2690a/prog/weave-kube/weave-daemonset-k8s-1.11.yaml -o /root/config/weave.yaml
+sed -i "s/weaveworks\/weave-kube:latest/weaveworks\/weave-kube:2.6.2/g" /root/config/weave.yaml
+sed -i "s/weaveworks\/weave-npc:latest/weaveworks\/weave-npc:2.6.2/g" /root/config/weave.yaml
+sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' /root/config/weave.yaml
 sed -i '0,/^              env:/s//              env:\n                - name: IPALLOC_RANGE\n                  value: POD_NETWORK_CIDR/' /root/config/weave.yaml
 
 echo '> Pre-Downloading Kubeadm Docker Containers'
@@ -17,8 +19,8 @@ k8s.gcr.io/kube-proxy:v1.14.9
 k8s.gcr.io/pause:3.1
 k8s.gcr.io/etcd:3.3.10
 k8s.gcr.io/coredns:1.3.1
-docker.io/weaveworks/weave-kube:2.6.0
-docker.io/weaveworks/weave-npc:2.6.0
+docker.io/weaveworks/weave-kube:2.6.2
+docker.io/weaveworks/weave-npc:2.6.2
 embano1/tinywww:latest
 projectcontour/contour:v1.0.0-beta.1
 openfaas/faas-netes:0.9.0


### PR DESCRIPTION
> Summary

The current method in which the Weave YAML is being downloaded from is not stable, meaning changes upstream can negatively affect things like change in Weave container image, which is what happened. Instead, we are no pulling the YAML from Weave github repo with a specific commit which ensures the version of the container we're using will always work. With this change, I've gone ahead and rev'ed to the latest version which is `2.6.2`

> Resolves

Close: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/102

> Testing

Deployed VEBA w/OpenFaa Processor against vSphere 6.7u3b and vSphere 7.0 build and verified the following:

Desired version of weave containers have already been downloaded:
```
root@veba [ ~ ]# docker images
REPOSITORY                           TAG                 IMAGE ID            CREATED             SIZE
weaveworks/weave-npc                 2.6.2               9860eea6ad44        2 weeks ago         36.7MB
weaveworks/weave-kube                2.6.2               573ccb81f66c        2 weeks ago         123MB
vmware/veba-event-router             latest              40af0186f445        3 weeks ago         119MB
...
```

All Pods are running after VEBA deployment:

```
root@veba [ ~ ]# kubectl get pods -A
NAMESPACE        NAME                                                READY   STATUS      RESTARTS   AGE
kube-system      coredns-584795fc57-8dtf8                            1/1     Running     0          19m
kube-system      coredns-584795fc57-qqqll                            1/1     Running     0          19m
kube-system      etcd-veba.primp-industries.com                      1/1     Running     0          18m
kube-system      kube-apiserver-veba.primp-industries.com            1/1     Running     0          18m
kube-system      kube-controller-manager-veba.primp-industries.com   1/1     Running     0          18m
kube-system      kube-proxy-x6vg7                                    1/1     Running     0          19m
kube-system      kube-scheduler-veba.primp-industries.com            1/1     Running     0          18m
kube-system      weave-net-kkfdh                                     2/2     Running     1          19m
openfaas         alertmanager-58f8d787d9-rwkp7                       1/1     Running     0          19m
openfaas         basic-auth-plugin-dd49cd66b-5jwjz                   1/1     Running     0          19m
openfaas         faas-idler-59ff9778fd-nfkdg                         1/1     Running     1          19m
openfaas         gateway-74f6f9489b-xmm5b                            2/2     Running     2          19m
openfaas         nats-6dfbf45d77-4hf69                               1/1     Running     0          19m
openfaas         prometheus-5f5494b54f-9pw6t                         1/1     Running     0          19m
openfaas         queue-worker-59b67bf4-2cblb                         1/1     Running     2          19m
projectcontour   contour-5cddfc8f6-l9x7x                             1/1     Running     0          19m
projectcontour   contour-5cddfc8f6-shqss                             1/1     Running     0          19m
projectcontour   contour-certgen-rm449                               0/1     Completed   0          19m
projectcontour   envoy-vk94x                                         1/1     Running     0          18m
vmware           tinywww-7fcfc6fb94-jdm6d                            1/1     Running     0          19m
vmware           vmware-event-router-5dd9c8f858-qsbxs                1/1     Running     2          19m
```

Signed-off-by: William Lam <wlam@vmware.com>