### PR TITLE
Fix VMware Event Router image pull to support air-gap scenario

### DIFF
--- a/files/setup-06-event-router.sh
+++ b/files/setup-06-event-router.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 echo -e "\e[92mDeploying VMware Event Router ..." > /dev/console
 kubectl --kubeconfig /root/.kube/config -n vmware create secret generic event-router-config --from-file=${EVENT_ROUTER_CONFIG}
 
+# Retrieve the version tag for VMware Event Router image
+EVENT_ROUTER_VERSION=$(awk '/Version:/ {print $2}' /etc/veba-release)
+
 cat > /root/config/event-router-k8s.yaml << __EVENT_ROUTER_CONFIG
 apiVersion: apps/v1
 kind: Deployment
@@ -27,7 +30,8 @@ spec:
         app: vmware-event-router
     spec:
       containers:
-      - image: vmware/veba-event-router:latest
+      - image: vmware/veba-event-router:${EVENT_ROUTER_VERSION}
+        imagePullPolicy: IfNotPresent
         args: ["-config", "/etc/vmware-event-router/event-router-config.json", "-verbose"]
         name: vmware-event-router
         resources:

--- a/photon.json
+++ b/photon.json
@@ -63,6 +63,9 @@
     },
     {
       "type": "shell",
+      "environment_vars": [
+        "VEBA_VERSION={{ user `VEBA_VERSION` }}"
+      ],
       "pause_before": "20s",
       "scripts": [
         "scripts/photon-containers.sh",

--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -32,7 +32,7 @@ envoyproxy/envoy:v1.11.1
 prom/prometheus:v2.11.0
 prom/alertmanager:v0.18.0
 nats-streaming:0.11.2
-vmware/veba-event-router:latest
+vmware/veba-event-router:${VEBA_VERSION}
 )
 
 for i in ${CONTAINERS[@]};


### PR DESCRIPTION
> Summary

Updated the logic on how the VMware Event Router image is pulled per https://github.com/vmware-samples/vcenter-event-broker-appliance/pull/105 and fixed Event Router K8s YAML to reflect the image version + imagePullPolicy for airgap/non-internet requirement

> Resolves

Close: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/102

> Testing

**Internal:** Deployed VEBA w/OpenFaa Processor against vSphere 7.0 build and verified deployment was successful and all pods were running as expected

**External:** Provided a build w/fixes to customer which has been verified https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/102#issuecomment-611537305

Signed-off-by: William Lam <wlam@vmware.com>