### PR TITLE
Add Function for Rest API Integrations (Slack, Pagerduty, JIRA, ServiceDesk, ZenDesk and ServiceNow)

### DIFF
--- a/examples/python/invoke-rest-api/README.MD
+++ b/examples/python/invoke-rest-api/README.MD
@@ -1,0 +1,199 @@
+# Function to make a POST request to any REST API
+
+This function aims to provide a easy way to make HTTP Post request to an API Endpoint that might help with a lot of integration scenarios. Eg. Post to a Slack channel, Create a PagerDuty or ServiceNow incident. 
+
+> **NOTE:** This function currently supports endpoints that allow basic authentication (un/pwd) or token based authentication that can be passed with the headers
+
+- [Deploy](#deploy)
+  * [Get the example function](#get-the-example-function)
+  * [Customize the function](#customize-the-function)
+    + [Understanding the Metaconfig-[SYSTEM].json](#understanding-the-metaconfig--system-json)
+      - [Provide the API Details](#provide-the-api-details)
+      - [Mapping the Events and Request body](#mapping-the-events-and-request-body)
+    + [Updating the Stack.yml](#updating-the-stackyml)
+    + [Updating the Handler.py (advanced)](#updating-the-handlerpy--advanced-)
+  * [Deploy the function](#deploy-the-function)
+    + [Create the secret](#create-the-secret)
+    + [Build function (only if handler.py is changed)](#build-function--only-if-handlerpy-is-changed-)
+    + [Deploy the function](#deploy-the-function-1)
+  * [Trigger the function](#trigger-the-function)
+- [Troubleshooting](#troubleshooting)
+
+# Deploy
+
+## Get the example function
+
+Clone this repository which contains the example functions. 
+
+```bash
+git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
+cd vcenter-event-broker-appliance/examples/python/invoke-rest-api
+git checkout master
+```
+
+## Customize the function
+
+There are three key files, that you might have to modify if you are looking to customize this function and make a post api call to an external system. 
+
+```bash
+  /invoke-rest-api/metaconfig-[SYSTEM].json #sample copies provided for PagerDuty, Slack, JIRA, Zendesk, ServiceDesk and ServiceNow
+  /invoke-rest-api/stack.yml 
+  /invoke-rest-api/handler/handler.py
+```
+
+### Understanding the Metaconfig-[SYSTEM].json 
+First, change the configuration file `metaconfig-[SYSTEM].json` (samples for Slack, PagerDuty and ServiceNow are provided with this example) holding both sensitive and configuration information needed for this function in this folder. 
+
+The `metaconfig-[SYSTEM].json` (as you can see below) has inputs needed to make a POST API request such as - `url, auth, headers` and `body`. These fields are self explanatory for an API and here are some of the considerations for this functions
+
+#### Provide the API Details
+* **url** - Http(s) endpoint to the System's API Endpoint. The function only does a POST call and this endpoint should be able to accept POST http request
+* **auth** - Most APIs provide some sort of API key to use and don't seem to require authentication credentials. While some others require basic authentication which can be send in the header. Where the API requires username and password explicitly, i've added that as an option in the config. The function requires the presence of the auth key in the config (it can be an empty dict if the API does not require any username/password for authentication)
+* **headers** - JSON key value pair of any headers that the API requires
+* **body** - currently support only json body (which most APIs should support)
+
+> **NOTE:** All these keys are required attributes. They can be empty if not required but if they are missing in the config then the function will fail. 
+
+
+#### Mapping the Events and Request body
+The `mapping` information provides a way to pull data from the Event that vCenter sends and replaces that within the request body before making the POST call.
+
+* `"pull": "data/FullFormattedMessage"` attempts to get the value of `FullFormattedMessage` within the `data` dict of the cloud Event that we receive from VMware Event Router
+* `"push": "payload/summary"` updates the `summary` field within the `payload` key of the request body as provided in this configuration file
+
+> **Note:** This function has been developed to handle VMPoweredOn(/Off)Event by default, which you can see in the provided samples. Please edit the mapping for other Events accordingly.
+
+```json
+{
+  "url": "https://events.pagerduty.com/v2/enqueue",
+  "auth": {
+    "un": "<username if required, leave blank if not required>",
+    "pwd": "<username if required, leave blank if not required>"
+  },
+  "headers": {
+    "Authorization":"Bearer <TOKEN>",
+    .....
+  },
+  "body": {
+    "payload": {
+      "summary": "Example alert on host1.example.com",
+      .....
+    }
+  },
+  "mappings": [
+    {
+      "push": "payload/summary",
+      "pull": "data/FullFormattedMessage"
+    }
+    .....
+  ]
+}
+```
+
+### Updating the Stack.yml
+Function-specific settings are performed in the `stack.yml` file such as gateway, image, environment variables, secrets(configs) and the topics(events) that this function will subscribe to. Open and edit the `stack.yml` provided to change as per your environment/needs.
+
+> **Note:** A key-value annotation under `topic` defines which VM event should trigger the function. A list of VM events from vCenter can be found [here](https://code.vmware.com/doc/preview?id=4206#/doc/vim.event.VmEvent.html). Multiple topics can be specified using a `","` delimiter syntax, e.g. "`topic: "VmPoweredOnEvent,VmPoweredOffEvent"`".
+
+```yaml
+provider:
+  name: openfaas
+  gateway: https://VEBA_FQDN_OR_IP              # replace with your vCenter Event Broker Appliance URL
+functions:
+  restpost-fn:
+    lang: python3
+    handler: ./handler
+    image: vmware/veba-python-restpost:latest
+    environment:
+      write_debug: true                         # additional debugging messages are printed
+      combine_output: false                     # required to prevent debug messages from showing up in faas response
+      read_debug: true
+      insecure_ssl: true                        # set to false if you have a trusted TLS certificate on VEBA 
+    secrets:
+      - metaconfig                              # leave as is, you will need to edit the function if this is changed
+    annotations:
+      topic: VmPoweredOnEvent,VmPoweredOffEvent # DrsVmPoweredOnEvent in a DRS-enabled cluster
+```
+
+> **Note:** If you are running a vSphere DRS-enabled cluster the topic annotation above should be `DrsVmPoweredOnEvent`. Otherwise the function would never be triggered.
+
+### Updating the Handler.py (advanced)
+You might have to edit this file if you are looking to possibly have multiple copies of this function running to make api calls to different system or to improve the function. 
+
+To have multiple copies of this function running, you'll need multiple metaconfigs for each system and end up creating multiple secrets for each config. The `handler.py` for each function will have to be updated to reference their respective secret. You can do this by updating the below line in the file
+
+```
+META_CONFIG='/var/openfaas/secrets/metaconfig-[SYSTEM]'
+```
+
+For others that are looking to update the function and make improvements, please have at it! 
+
+## Deploy the function
+
+For the most part (if you didn't have to edit the handler.py), you'll have to create the secret and deploy the function. 
+
+### Create the secret
+Let's store the configuration file as secret in the appliance.
+
+```bash
+# set up faas-cli for first use
+export OPENFAAS_URL=https://VEBA_FQDN_OR_IP
+faas-cli login -p VEBA_OPENFAAS_PASSWORD --tls-no-verify # vCenter Event Broker Appliance is configured with authentication, pass in the password used during the vCenter Event Broker Appliance deployment process
+
+# now create the secret
+faas-cli secret create metaconfig --from-file=metaconfig-[SYSTEM].json --tls-no-verify
+```
+
+> **Note:** Delete the local `metaconfig-[SYSTEM].json` after you're done with this exercise to not expose any sensitive information.
+
+### Build function (only if handler.py is changed)
+
+> **NOTE:** This is only required if you changed the `handler.py` 
+
+ Under the hoods, the functions are deployed as a container. Usually these containers are built and made readily available for you with the example function. However, when you make changes the function, you'll have to build the function and build the container. 
+
+```bash 
+faas-cli template pull
+
+faas-cli build
+
+faas-cli push #optional if you are pushing to DockerHub 
+```
+
+> **NOTE:** Make sure the `image` tag in the `stack.yml` is updated to reference the correct image. 
+
+### Deploy the function
+After you've performed the steps and modifications above, you can go ahead and deploy the function:
+
+```bash
+faas-cli deploy -f stack.yml --tls-no-verify
+Deployed. 202 Accepted.
+```
+
+## Trigger the function
+
+Turn on a virtual machine, e.g. in vCenter or via `govc` CLI, to trigger the function via a `(DRS)VmPoweredOnEvent`. Verify that the API was correctly called. 
+
+> **Note:** If the API doesn't get called verify that you correctly followed each step above, IPs/FQDNs and credentials are correct and see the [troubleshooting](#troubleshooting) section below.
+
+# Troubleshooting
+
+If the API doesn't get called, verify:
+
+- Validate that the API call works with Postman or cURL
+- Validate the configurations provided within the `metaconfig-[SYSTEM].json`
+- Validate the `stack.yml` file and the topic being subscribed to
+- Verify if the components can talk to each other (VMware Event Router to vCenter and OpenFaaS, VMware Event Broker Appliance to API)
+- Check the logs:
+
+```bash
+faas-cli logs restpost-fn --follow --tls-no-verify 
+
+# Successful log message in the OpenFaaS tagging function
+2019/01/25 23:48:55 Forking fprocess.
+2019/01/25 23:48:55 Query
+2019/01/25 23:48:55 Path  /
+......
+{"status": "200", "message": "Successfully executed the REST API call"}
+2019/01/25 23:48:56 Duration: 1.551482 seconds
+```

--- a/examples/python/invoke-rest-api/handler/handler.py
+++ b/examples/python/invoke-rest-api/handler/handler.py
@@ -1,0 +1,248 @@
+import sys, json, os
+import urllib3
+import requests
+import dpath.util
+import traceback
+
+# GLOBAL_VARS
+DEBUG=False
+class bgc:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+if(os.getenv("insecure_ssl")):
+    # Surpress SSL warnings
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+if(os.getenv("write_debug")):
+    sys.stderr.write(f"{bgc.WARNING}WARNING!! DEBUG has been enabled for this function. Sensitive information could be printed to sysout{bgc.ENDC} \n")
+    DEBUG=True
+
+def debug(s):
+    if DEBUG:
+        sys.stderr.write(s+" \n") #Syserr only get logged on the console logs
+
+#
+### Paths and Endpoints
+### More examples and details here - https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
+#
+META_CONFIG='/var/openfaas/secrets/metaconfig'
+
+class FaaSResponse:
+    """
+    FaaSResponse is a helper class to construct a properly formatted message returned by this function.
+    By default, OpenFaaS will marshal this response message as JSON.
+    """    
+    def __init__(self, status, message):
+        """
+        Arguments:
+            status {str} -- the response status code
+            message {str} -- the response message
+        """    
+        self.status=status
+        self.message=message
+
+class RESTful:
+    """
+    RESTful is a class which aims to make Rest API calls easily without writing any code
+    """    
+
+    def __init__(self, conn, config, event):
+        """
+        Constructor for RESTful class
+        
+        Arguments:
+            conn {session} -- [Request Connection]
+            config {dict} -- [Config with URL, Body and Mapping for Rest API call]
+            event {dict} -- [Cloud Event from vCenter]
+        """   
+        self.session = conn
+        self.config = config
+        self.event = event
+    
+    def geturl(self):
+        """
+        Getter for the URL to make the call
+        
+        Returns:
+            [string] -- [URL for the Rest API endpoint]
+        """
+        url = self.config['url']
+        return url
+    
+    def getheaders(self): 
+        header = self.config['headers']
+        return header
+    
+    def getauth(self): 
+        ref = self.config['auth']
+        try:
+            auth = (ref['un'], ref['pwd'])
+        except (TypeError,KeyError) as err:
+            debug(f'Unexpected auth param provided, assuming no auth > "{ref}"')
+            auth = None
+        return auth
+    
+    def getbody(self): 
+        """
+        Getter for the Request Body to make the call
+        
+        Returns:
+            [dict] -- [JSON constructed body]
+        """
+        body = self.config['body']
+        mappings = self.config['mappings']
+        for mapping in mappings:
+            pushvalue = mapping['push']
+            pullvalue = mapping['pull']
+            #debug(f'Attempting mapping of Body:{pushvalue} with CloudEvent:{pullvalue}')
+            #debug(f'Replacing >>> {dpath.util.get(body, pushvalue)} with ::: {dpath.util.get(self.event, pullvalue)}')
+            dpath.util.set(body, pushvalue, dpath.util.get(self.event, pullvalue))
+        return body
+
+    # PagerDuty REST API implementation        
+    def post(self):
+        """
+        Function to make the POST call to the endpoint
+        
+        Returns:
+            [FaaSResponse] -- [Formatted message for OpenFaaS]
+        """
+        
+        urlPath = self.geturl()
+        debug(f'{bgc.OKBLUE}> URL: {bgc.ENDC}{urlPath}')
+        authObj = self.getauth()
+        #debug(f'{bgc.OKBLUE}> Auth: {bgc.ENDC}{authObj}') #don't want auth printed
+        headerObj = self.getheaders()
+        debug(f'{bgc.OKBLUE}> Headers: {bgc.ENDC}{json.dumps(headerObj, indent=4)}')
+        bodyObj = self.getbody()
+        debug(f'{bgc.OKBLUE}> Body: {bgc.ENDC}{json.dumps(bodyObj, indent=4)}')
+        try:
+            resp = self.session.post(urlPath, auth=authObj, json=bodyObj, headers=headerObj)
+            resp.raise_for_status()
+            try:
+                resp_body = json.loads(resp.text)
+                debug(f'{bgc.OKBLUE}> Response: {bgc.ENDC}{json.dumps(resp_body, indent=4, sort_keys=True)}')
+            except json.JSONDecodeError as err:
+                debug(f'{bgc.OKBLUE}> Response: {bgc.ENDC}{resp.text}') #some apis don't return json
+            
+            return FaaSResponse('200', f'Response:{resp.text}')
+        except requests.HTTPError as err:
+            return FaaSResponse('500', 'Could not executed REST API > HTTPError: {0}'.format(err))
+
+def handle(req):
+    
+    # Load the Events that function gets from vCenter through the Event Router
+    debug(f'{bgc.HEADER}Reading Cloud Event: {bgc.ENDC}')
+    debug(f'{bgc.OKBLUE}Event > {bgc.ENDC}{req}')
+    try:
+        cevent = json.loads(req)
+    except json.JSONDecodeError as err:
+        res = FaaSResponse('400','Invalid JSON > JSONDecodeError: {0}'.format(err))
+        print(json.dumps(vars(res)))
+        return
+
+    # Load the Config File
+    debug(f'{bgc.HEADER}Reading Configuration file: {bgc.ENDC}')
+    debug(f'{bgc.OKBLUE}Config File > {bgc.ENDC}{META_CONFIG}')
+    try: 
+        with open(META_CONFIG, 'r') as prodconfig:
+            metaconfig = json.load(prodconfig)
+    except json.JSONDecodeError as err:
+        res = FaaSResponse('400','Invalid JSON > JSONDecodeError: {0}'.format(err))
+        print(json.dumps(vars(res)))
+        return
+    except OSError as err:
+        res = FaaSResponse('500','Could not read configuration > OSError: {0}'.format(err))
+        print(json.dumps(vars(res)))
+        return
+
+    #Validate CloudEvent and Configuration for mandatory fields
+    debug(f'{bgc.HEADER}Validating Input data and mapping: {bgc.ENDC}')
+    debug(f'{bgc.OKBLUE}Event > {bgc.ENDC}{json.dumps(cevent, indent=4, sort_keys=True)}')
+    debug(f'{bgc.OKBLUE}Config > {bgc.ENDC}{json.dumps(metaconfig, indent=4, sort_keys=True)}')
+    try:
+        #CloudEvent - simple validation
+        event = cevent['data']
+        
+        #Config - checking for required fields
+        url = metaconfig['url'] #not validating if an actual URL is provided
+        auth = metaconfig['auth'] #auth can be empty for no auth but a required key
+        headers = metaconfig['headers'] #not validating sanctity of headers
+        body = metaconfig['body'] #json only supported
+        mappings = metaconfig['mappings'] #mapping can be empty array but the key needs to be present in the config
+        
+        #supports 1-1 event-config mapping. next iteration can take complex 1-*(seperated by comma) mapping that will allow building out strings with values from the event
+        for mapping in mappings:
+            pushvalue = mapping['push']
+            debug(f'Config has key "{pushvalue}" >>> "{dpath.util.get(body, pushvalue)}"')
+            pullvalue = mapping['pull']
+            debug(f'Event has key "{pullvalue}" >>> "{dpath.util.get(cevent, pullvalue)}"')
+    except KeyError as err:
+        res = FaaSResponse('400','Invalid JSON, required key not found > KeyError: {0}'.format(err))
+        traceback.print_exc(limit=1, file=sys.stderr) #providing traceback since it helps debug the exact key that failed
+        print(json.dumps(vars(res)))
+        return
+    except ValueError as err:
+        res = FaaSResponse('400','Invalid mapping, multiple keys found > ValueError: {0}'.format(err))
+        traceback.print_exc(limit=1, file=sys.stderr) #providing traceback since it helps debug the exact key that failed
+        print(json.dumps(vars(res)))
+        return
+
+    # Make the Rest Api Call
+    s=requests.Session()
+    if(os.getenv("insecure_ssl")):
+        s.verify=False
+    
+    # with the metaconfig - which is the configuration file with the URL and body to make the call
+    # and with the cloud event - which is the event generated from vCenter
+    # we are going to build the request body and make the rest api call
+    debug(f'{bgc.HEADER}Attemping HTTP POST: {bgc.ENDC}')
+    try:
+        restful = RESTful(s, metaconfig, cevent)
+        res = restful.post()
+        print(json.dumps(vars(res)))
+    except Exception as err:
+        res = FaaSResponse('500','Unexpected error occurred > Exception: {0}'.format(err))
+        traceback.print_exc(limit=1, file=sys.stderr) #providing traceback since it helps debug the exact key that failed
+        print(json.dumps(vars(res)))
+        
+    s.close()
+
+    return
+
+#
+## Unit Test - helps testing the function locally
+## Uncomment META_CONFIG - update the path to the file accordingly
+## Uncomment handle('...') to test the function with the event samples provided below test without deploying to OpenFaaS
+#
+#META_CONFIG='metaconfig-pduty.json'
+
+#
+## FAILURE CASES :Invalid Inputs
+#
+#handle('')
+#handle('"test":"ok"')
+#handle('{"test":"ok"}')
+#handle('{"data":"ok"}')
+
+#
+## FAILURE CASES :Unhandled Events
+# 
+# Standard : UserLogoutSessionEvent
+#handle('{"id":"17e1027a-c865-4354-9c21-e8da3df4bff9","source":"https://vcsa.pdotk.local/sdk","specversion":"1.0","type":"com.vmware.event.router/event","subject":"UserLogoutSessionEvent","time":"2020-04-14T00:28:36.455112549Z","data":{"Key":7775,"ChainId":7775,"CreatedTime":"2020-04-14T00:28:35.221698Z","UserName":"machine-b8eb9a7f","Datacenter":null,"ComputeResource":null,"Host":null,"Vm":null,"Ds":null,"Net":null,"Dvs":null,"FullFormattedMessage":"User machine-b8ebe7eb9a7f@127.0.0.1 logged out (login time: Tuesday, 14 April, 2020 12:28:35 AM, number of API invocations: 34, user agent: pyvmomi Python/3.7.5 (Linux; 4.19.84-1.ph3; x86_64))","ChangeTag":"","IpAddress":"127.0.0.1","UserAgent":"pyvmomi Python/3.7.5 (Linux; 4.19.84-1.ph3; x86_64)","CallCount":34,"SessionId":"52edf160927","LoginTime":"2020-04-14T00:28:35.071817Z"},"datacontenttype":"application/json"}')
+# Eventex : vim.event.ResourceExhaustionStatusChangedEvent
+#handle('{"id":"0707d7e0-269f-42e7-ae1c-18458ecabf3d","source":"https://vcsa.pdotk.local/sdk","specversion":"1.0","type":"com.vmware.event.router/eventex","subject":"vim.event.ResourceExhaustionStatusChangedEvent","time":"2020-04-14T00:20:15.100325334Z","data":{"Key":7715,"ChainId":7715,"CreatedTime":"2020-04-14T00:20:13.76967Z","UserName":"machine-bb9a7f","Datacenter":null,"ComputeResource":null,"Host":null,"Vm":null,"Ds":null,"Net":null,"Dvs":null,"FullFormattedMessage":"vCenter Log File System Resource status changed from Yellow to Green on vcsa.pdotk.local  ","ChangeTag":"","EventTypeId":"vim.event.ResourceExhaustionStatusChangedEvent","Severity":"info","Message":"","Arguments":[{"Key":"resourceName","Value":"storage_util_filesystem_log"},{"Key":"oldStatus","Value":"yellow"},{"Key":"newStatus","Value":"green"},{"Key":"reason","Value":" "},{"Key":"nodeType","Value":"vcenter"},{"Key":"_sourcehost_","Value":"vcsa.pdotk.local"}],"ObjectId":"","ObjectType":"","ObjectName":"","Fault":null},"datacontenttype":"application/json"}')
+
+#
+## SUCCESS CASES
+#
+# Standard : VmPoweredOnEvent
+#handle('{"id":"453120cd-3d19-4c43-aadc-df0cdbce3887","source":"https://vcsa.pdotk.local/sdk","specversion":"1.0","type":"com.vmware.event.router/event","subject":"VmPoweredOnEvent","time":"2020-04-13T23:46:10.402531287Z","data":{"Key":7441,"ChainId":7438,"CreatedTime":"2020-04-13T23:46:09.387283Z","UserName":"Administrator","Datacenter":{"Name":"PKLAB","Datacenter":{"Type":"Datacenter","Value":"datacenter-3"}},"ComputeResource":{"Name":"esxi01.pdotk.local","ComputeResource":{"Type":"ComputeResource","Value":"domain-s29"}},"Host":{"Name":"esxi01.pdotk.local","Host":{"Type":"HostSystem","Value":"host-31"}},"Vm":{"Name":"Test VM","Vm":{"Type":"VirtualMachine","Value":"vm-33"}},"Ds":null,"Net":null,"Dvs":null,"FullFormattedMessage":"Test VM on esxi01.pdotk.local in PKLAB has powered on","ChangeTag":"","Template":false},"datacontenttype":"application/json"}')
+# Standard : VmPoweredOffEvent
+#handle('{"id":"d77a3767-1727-49a3-ac33-ddbdef294150","source":"https://vcsa.pdotk.local/sdk","specversion":"1.0","type":"com.vmware.event.router/event","subject":"VmPoweredOffEvent","time":"2020-04-14T00:33:30.838669841Z","data":{"Key":7825,"ChainId":7821,"CreatedTime":"2020-04-14T00:33:30.252792Z","UserName":"Administrator","Datacenter":{"Name":"PKLAB","Datacenter":{"Type":"Datacenter","Value":"datacenter-3"}},"ComputeResource":{"Name":"esxi01.pdotk.local","ComputeResource":{"Type":"ComputeResource","Value":"domain-s29"}},"Host":{"Name":"esxi01.pdotk.local","Host":{"Type":"HostSystem","Value":"host-31"}},"Vm":{"Name":"Test VM","Vm":{"Type":"VirtualMachine","Value":"vm-33"}},"Ds":null,"Net":null,"Dvs":null,"FullFormattedMessage":"Test VM on  esxi01.pdotk.local in PKLAB is powered off","ChangeTag":"","Template":false},"datacontenttype":"application/json"}')

--- a/examples/python/invoke-rest-api/handler/requirements.txt
+++ b/examples/python/invoke-rest-api/handler/requirements.txt
@@ -1,0 +1,3 @@
+urllib3==1.25.6
+requests==2.22.0
+dpath==2.0.1

--- a/examples/python/invoke-rest-api/metaconfig-jira.json
+++ b/examples/python/invoke-rest-api/metaconfig-jira.json
@@ -1,0 +1,34 @@
+{
+    "url": "https://pk-sdesk.atlassian.net/rest/api/2/issue",
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept": "application/json; charset=UTF-8"
+    },
+    "auth": {
+        "un": "<username required>",
+        "pwd": "<password required>"
+    },
+    "body": {
+        "fields": {
+           "project":
+           {
+              "key": "VEBA"
+           },
+           "summary": "REST ye merry gentlemen.",
+           "description": "Creating of an issue using project keys and issue type names using the REST API",
+           "issuetype": {
+              "name": "Bug"
+           }
+       }
+    },
+    "mappings": [
+        {
+            "push": "fields/summary",
+            "pull": "data/FullFormattedMessage"
+        },
+        {
+            "push": "fields/description",
+            "pull": "data/FullFormattedMessage"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/metaconfig-pduty.json
+++ b/examples/python/invoke-rest-api/metaconfig-pduty.json
@@ -1,0 +1,60 @@
+{
+    "url": "https://events.pagerduty.com/v2/enqueue",
+    "headers": {
+        "content-type": "application/json; charset=UTF-8"
+    },
+    "auth": {},
+    "body": {
+        "event_action": "trigger",
+        "client": "VMware Event Broker Appliance",
+        "client_url": "https://veba-dev",
+        "routing_key": "<required integration key>",
+        "payload": {
+          "summary": "Example alert on host1.example.com",
+          "timestamp": "2015-07-17T08:42:58.315+0000",
+          "source": "monitoringtool:cloudvendor:central-region-dc-01:852559987:cluster/api-stats-prod-003",
+          "severity": "info",
+          "component": "postgres",
+          "group": "prod-datapipe",
+          "class": "deploy",
+          "custom_details": {
+            "ping time": "1500ms",
+            "load avg": 0.75
+          }
+        }
+    },
+    "mappings": [
+        {
+            "push": "payload/summary",
+            "pull": "data/FullFormattedMessage"
+        },
+        {
+            "push": "payload/timestamp",
+            "pull": "time"
+        },
+        {
+            "push": "payload/source",
+            "pull": "source"
+        },
+        {
+            "push": "payload/component",
+            "pull": "data/Vm/Name"
+        },
+        {
+            "push": "payload/group",
+            "pull": "data/Host/Name"
+        },
+        {
+            "push": "payload/class",
+            "pull": "subject"
+        },
+        {
+            "push": "client",
+            "pull": "source"
+        },
+        {
+            "push": "client_url",
+            "pull": "source"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/metaconfig-sdesk.json
+++ b/examples/python/invoke-rest-api/metaconfig-sdesk.json
@@ -1,0 +1,32 @@
+{
+    "url": "https://pk-sdesk.atlassian.net/rest/servicedeskapi/request",
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept": "application/json; charset=UTF-8"
+    },
+    "auth": {
+        "un": "<username required>",
+        "pwd": "<password required>"
+    },
+    "body": {
+        "serviceDeskId": "1",
+        "requestTypeId": "10007",
+        "requestFieldValues": {
+            "summary": "Request JSD help via REST",
+            "description": "I need a new mouse for my Mac"
+        },
+        "requestParticipants": [
+            "qm:2bce408d-160f-4209-a12d-4939013fba18:71b91e5d-b836-4078-bcae-a43d303fd3a6"
+        ]
+    },
+    "mappings": [
+        {
+            "push": "requestFieldValues/summary",
+            "pull": "data/FullFormattedMessage"
+        },
+        {
+            "push": "requestFieldValues/description",
+            "pull": "data/FullFormattedMessage"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/metaconfig-slack.json
+++ b/examples/python/invoke-rest-api/metaconfig-slack.json
@@ -1,0 +1,76 @@
+{
+    "url": "https://<incoming-web-hook>.slack.com/services/T024....FIe",
+    "headers": {
+        "content-type": "application/json; charset=UTF-8"
+    },
+    "auth": {},
+    "body": {
+        "text": "Title",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Title"
+                }
+            },
+            {
+                "type": "section",
+                "block_id": "section567",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Description"
+                },
+                "accessory": {
+                    "type": "image",
+                    "image_url": "https://clipartart.com/images/vmware-esxi-clipart-2.jpg",
+                    "alt_text": "vCenter"
+                },
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "Additional Detail"
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": "Additional Detail"
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": "Additional Detail"
+                    }
+                ]
+            }
+        ]
+    },
+    "mappings": [
+        {
+            "push": "text",
+            "pull": "subject"
+        },
+        {
+            "push": "blocks/[0]/text/text",
+            "pull": "subject"
+        },
+        {
+            "push": "blocks/[1]/text/text",
+            "pull": "data/FullFormattedMessage"
+        },
+        {
+            "push": "blocks/[1]/accessory/alt_text",
+            "pull": "source"
+        },
+        {
+            "push": "blocks/[1]/fields/[0]/text",
+            "pull": "data/Datacenter/Datacenter/Value"
+        },
+        {
+            "push": "blocks/[1]/fields/[1]/text",
+            "pull": "data/Host/Host/Value"
+        },
+        {
+            "push": "blocks/[1]/fields/[2]/text",
+            "pull": "data/Vm/Vm/Value"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/metaconfig-snow.json
+++ b/examples/python/invoke-rest-api/metaconfig-snow.json
@@ -1,0 +1,20 @@
+{
+    "url": "https://<instance>.service-now.com/api/now/table/incident?sysparm_limit=1",
+    "headers": {
+        "content-type": "application/json; charset=UTF-8"
+    },
+    "auth": {
+        "un": "<username required>",
+        "pwd": "<password required>"
+    },
+    "body": {
+        "short_description":"Test incident creation through REST", 
+        "comments":"VEBA > Please validate this incident"
+    },
+    "mappings": [
+        {
+            "push": "short_description",
+            "pull": "data/FullFormattedMessage"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/metaconfig-zdesk.json
+++ b/examples/python/invoke-rest-api/metaconfig-zdesk.json
@@ -1,0 +1,25 @@
+{
+    "url": "https://pk-zen.zendesk.com/api/v2/tickets.json",
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept": "application/json; charset=UTF-8"
+    },
+    "auth": {
+        "un": "<username required>",
+        "pwd": "<password required>"
+    },
+    "body": {
+        "ticket": {
+          "subject": "My printer is on fire!",
+          "comment": {
+            "body": "VEBA: Please look into this ASAP"
+          }
+        }
+    },
+    "mappings": [
+        {
+            "push": "ticket/subject",
+            "pull": "data/FullFormattedMessage"
+        }
+    ]
+}

--- a/examples/python/invoke-rest-api/stack.yml
+++ b/examples/python/invoke-rest-api/stack.yml
@@ -1,0 +1,18 @@
+version: 1.0
+provider:
+  name: openfaas
+  gateway: https://VEBA_FQDN_OR_IP
+functions:
+  restpost-fn:
+    lang: python3
+    handler: ./handler
+    image: vmware/veba-python-restpost:latest
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+      insecure_ssl: true
+    secrets:
+      - metaconfig
+    annotations:
+      topic: VmPoweredOnEvent,VmPoweredOffEvent


### PR DESCRIPTION
This function is the Postman or cURL for VEBA and can make a POST api call to any endpoint that supports basic, token auth in headers or no authentication. 
Sample configs provided for above mentioned endpoints
Debug messages print to stderr, does not show in FaaS Response. 
Unit tests available in handle.py, uncomment to test locally

**Testing**: 
Environment: vCenter 6.7 and VEBA v0.3(w/ OpenFaaS)
This function was tested against the following APIs/Systems (configs provided
- Slack (send message to a channel)
- PagerDuty (trigger an incident) and 
- ServiceNow (create an incident) 
- ServiceDesk (create a request)
- JIRA (create a JIRA issue)
- Zendesk (create a ticket) 

Signed-off-by: pksrc <kandasamyp@vmware.com>