### PR TITLE
Support datastore custom attribute as To: address

### DIFF
--- a/examples/powercli/datastore-usage-email/README.md
+++ b/examples/powercli/datastore-usage-email/README.md
@@ -16,7 +16,15 @@ git checkout master
 
 Step 2 - Update `stack.yml` and `vc-datastore-config.json` with your environment information
 
-> **Note:** leave SMTP_USERNAME and SMTP_PASSWORD blank if you do not want to use authenticated SMTP
+> **Note:**
+ Leave SMTP_USERNAME and SMTP_PASSWORD blank if you do not want to use authenticated SMTP
+
+The function supports pulling a To: email address from a custom attribute in vCenter. This allows administrators with vCenter access to configure email notifications without having to alter the JSON script configuration. To enable this feature, do the following:
+- Create a custom attribute in vCenter, assign it to a datastore and give it an email address. For example, create a custom attribute named `NotifyEmail` and assign it a value of `admin@foo.com`
+- In `vc-datastore-config.json`, add the name of the custom attribute `NotifyEmail` as the value for `DATASTORE_CUSTOM_PROP_EMAIL_TO`
+- Add a vCenter URL and credentials to `VC`, `VC_USERNAME`, and `VC_PASSWORD`
+
+When this is configured, an email address found in the custom attribute will be added to the email already defined in the `EMAIL_TO` section of the JSON file. 
 
 Step 3 - Login to the OpenFaaS gateway on vCenter Event Broker Appliance
 

--- a/examples/powercli/datastore-usage-email/handler/script.ps1
+++ b/examples/powercli/datastore-usage-email/handler/script.ps1
@@ -36,25 +36,85 @@ if( ("$alarmName" -match "$($VC_CONFIG.VC_ALARM_NAME)") -and ([bool]($VC_CONFIG.
     } elseif($alarmStatus -eq "green") {
         $subject = "$($VC_CONFIG.EMAIL_SUBJECT)"
         $threshold = "normal"
-    }
+	}
 
     $Body = "$alarmName $datastoreName has reached $threshold threshold.`r`n"
-    
-    if ( $threshold -ne "normal" ) {
-        $Body = $Body + "Please log in to your VMware Cloud on AWS environment and ensure that everything is operating as expected.`r`n"
-    }
+	
+	if ( $threshold -ne "normal" )
+	{
+		$Body = $Body + "Please log in to your VMware Cloud on AWS environment and ensure that everything is operating as expected.`r`n"
+	}
 
-    $Body = $Body + @"
-        vCenter Server: $vcenter
+	$Body = $Body + @"
+	    vCenter Server: $vcenter
         Datacenter: $datacenter
         Datastore: $datastoreName	
 "@
-    if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0) {
-        $password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
-        $credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
-        Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
-    } else {
-        Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
-    }
-}
 
+    $emailTo = $VC_CONFIG.EMAIL_TO 
+    
+    # If the JSON file has a custom property email field defined, log into vCenter to find the value
+    # This is used to allow admins within vCenter to add an email address for storage alarms independent of the EMAIL_TO value
+    if ($VC_CONFIG.DATASTORE_CUSTOM_PROP_EMAIL_TO.length -gt 0)
+    {
+        Set-PowerCLIConfiguration -InvalidCertificateAction Ignore  -DisplayDeprecationWarnings $false -ParticipateInCeip $false -Confirm:$false | Out-Null
+        
+        # Connect to vCenter Server
+        Write-Host "Connecting to vCenter Server ..."
+        Connect-VIServer -Server $($VC_CONFIG.VC) -User $($VC_CONFIG.VC_USERNAME) -Password $($VC_CONFIG.VC_PASSWORD)
+
+        # This objet has all defined custom fields in the vCenter
+        $customFieldMgr = Get-View ($global:DefaultVIServer.ExtensionData.Content.CustomFieldsManager)
+
+        $datastoreView = Get-View -ViewType Datastore -Property Name, Value -Filter @{"name"=$datastoreName}
+
+        # Build 2 hash tables for the key-value pairs in the Custom Fields Manager, one to search by Custom Field ID and one to search by Name
+        $customKeyLookup = @{}
+        $customNameLookup = @{}
+        $customFieldMgr.Field | ForEach-Object {
+            $customKeyLookup.Add($_.Key, $_.Name)          
+            $customNameLookup.Add($_.Name, $_.Key)
+        }
+
+        # This is the custom field that we're looking to pull an email address out of
+        $emailKey = $customNameLookup[$($VC_CONFIG.DATASTORE_CUSTOM_PROP_EMAIL_TO)]
+
+        #If we find one, this is the email address we will add to the "To" field in the email
+        $addEmailAddress = ""
+        foreach ($row in $datastoreView.Value) {
+            if ($env:function_debug -eq "true") {
+                Write-Host "`Datastore:" $datastoreName "has Custom Field:" $customKeyLookup[$row.Key] "with value:" $row.Value "`n"
+            }
+            if ($row.Key -eq $emailKey) 
+            {
+                if ($env:function_debug -eq "true") {
+                    write-host "Found key" $emailKey "with value" $row.value
+                }
+                $addEmailAddress = $row.value
+            }
+
+        }
+        
+        if ($addEmailAddress.length -gt 0){
+            $emailTo = $emailTo + $addEmailAddress
+        }
+        else {
+            Write-Host "DATASTORE_CUSTOM_PROP_EMAIL_TO value '"$VC_CONFIG.DATASTORE_CUSTOM_PROP_EMAIL_TO "' found in JSON config but not found on datastore"
+        }
+        Write-Host "Disconnecting from vCenter Server ..."
+        Disconnect-VIServer * -Confirm:$false
+
+    }
+
+    # If defined in the config file, send via authenticated SMTP, otherwise use standard SMTP
+	if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0)
+	{
+		$password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
+		$credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
+		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($emailTo)  -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential -Encoding UTF32
+	}
+	else
+	{
+		Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($emailTo) -Subject $Subject -Body $Body -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
+	}
+}

--- a/examples/powercli/datastore-usage-email/vc-datastore-config.json
+++ b/examples/powercli/datastore-usage-email/vc-datastore-config.json
@@ -7,5 +7,9 @@
     "SMTP_PASSWORD" : "FILE-ME-IN-PLEASE",
     "EMAIL_SUBJECT" : "[VMC Datastore Notification Alarm]",
     "EMAIL_TO": ["admins@primp-industries.com"],
-    "EMAIL_FROM" : "vmc-notification-do-not-reply@primp-industries.com"
+    "EMAIL_FROM" : "vmc-notification-do-not-reply@primp-industries.com",
+    "DATASTORE_CUSTOM_PROP_EMAIL_TO" : "",
+    "VC" : "",
+    "VC_USERNAME" : "",
+    "VC_PASSWORD" : ""
 }


### PR DESCRIPTION
Support for a custom attribute added to the datastore containing an additional To: address.Gives vCenter admins the ability to configure recipient directly in vCenter without having to modify and push a new JSON secret.

Testing: Tested on vCenter 7 and VMC SDDC M9 with VEBA 0.3 release. Validated successful email delivery with all possible combinations of: authenticated SMTP, unauthenticated SMTP, custom attribute present, and custom attribute not present

Signed-off-by: Patrick Kremer <pkremer@vmware.com>