### PR TITLE
Replace Weave with Antrea CNI 

### DIFF
--- a/files/setup-01-os.sh
+++ b/files/setup-01-os.sh
@@ -21,3 +21,7 @@ if [ "${DOCKER_NETWORK_CIDR}" != "172.17.0.1/16" ]; then
 EOF
 systemctl restart docker
 fi
+
+echo -e "\e[92mConfiguring IP Tables for Antrea ..." > /dev/console
+iptables -A INPUT -i gw0 -j ACCEPT
+iptables-save > /etc/systemd/scripts/ip4save

--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -125,8 +125,8 @@
             <Label>Docker Bridge CIDR Network</Label>
             <Description>Customize Docker Bridge CIDR Network (Default 172.17.0.1/16)</Description>
         </Property>
-        <Property ovf:key="guestinfo.pod_network_cidr" ovf:type="string" ovf:userConfigurable="true" ovf:value="10.99.0.0/20">
+        <Property ovf:key="guestinfo.pod_network_cidr" ovf:type="string" ovf:userConfigurable="true" ovf:value="10.10.0.0/16">
             <Label>POD CIDR Network</Label>
-            <Description>Customize POD CIDR Network (Default 10.99.0.0/20)</Description>
+            <Description>Customize POD CIDR Network (Default 10.10.0.0/16)</Description>
         </Property>
     </ProductSection>

--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -2,13 +2,6 @@
 # Copyright 2019 VMware, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2
 
-echo '> Downloading weave.yaml'
-curl -L https://raw.githubusercontent.com/weaveworks/weave/9f00f78d3b9d5a8a31fdd90ec691095028e2690a/prog/weave-kube/weave-daemonset-k8s-1.11.yaml -o /root/config/weave.yaml
-sed -i "s/weaveworks\/weave-kube:latest/weaveworks\/weave-kube:2.6.2/g" /root/config/weave.yaml
-sed -i "s/weaveworks\/weave-npc:latest/weaveworks\/weave-npc:2.6.2/g" /root/config/weave.yaml
-sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' /root/config/weave.yaml
-sed -i '0,/^              env:/s//              env:\n                - name: IPALLOC_RANGE\n                  value: POD_NETWORK_CIDR/' /root/config/weave.yaml
-
 echo '> Pre-Downloading Kubeadm Docker Containers'
 
 CONTAINERS=(
@@ -19,8 +12,7 @@ k8s.gcr.io/kube-proxy:v1.14.9
 k8s.gcr.io/pause:3.1
 k8s.gcr.io/etcd:3.3.10
 k8s.gcr.io/coredns:1.3.1
-docker.io/weaveworks/weave-kube:2.6.2
-docker.io/weaveworks/weave-npc:2.6.2
+antrea/antrea-ubuntu:v0.6.0
 embano1/tinywww:latest
 projectcontour/contour:v1.0.0-beta.1
 openfaas/faas-netes:0.9.0
@@ -56,3 +48,8 @@ git checkout v1.0.0-beta.1
 sed -i '/^---/i \      dnsPolicy: ClusterFirstWithHostNet\n      hostNetwork: true' examples/contour/03-envoy.yaml
 sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' examples/contour/*.yaml
 cd ..
+
+echo '> Downloading Antrea...'
+wget https://github.com/vmware-tanzu/antrea/releases/download/v0.6.0/antrea.yml -O /root/download/antrea.yml
+sed -i 's/image: antrea\/antrea-ubuntu:.*/image: antrea\/antrea-ubuntu:v0.6.0/g' /root/download/antrea.yml
+sed -i '/image:.*/i \        imagePullPolicy: IfNotPresent' /root/download/antrea.yml

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -13,6 +13,7 @@ echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 
 echo '> Applying latest Updates...'
 tdnf -y update
+tdnf upgrade linux-esx
 
 echo '> Installing Additional Packages...'
 tdnf install -y \


### PR DESCRIPTION
> Summary

This changes contains the configuration updates to support Antrea as the default CNI instead of Weave. v0.6.0 was used as it contained a fix which was identified during the research phase. 

> Resolves

Closes: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/16

> Testing

Deployed VEBA w/OpenFaa Processor against vSphere 7.0 build and verified deployment was successful and all pods were running as expected

<img width="1167" alt="Screen Shot 2020-04-30 at 2 49 37 PM" src="https://user-images.githubusercontent.com/602199/80763400-48b92280-8af3-11ea-8a10-04909648be31.png">

Signed-off-by: William Lam <wlam@vmware.com>