### PR TITLE
Add Github Action to push Docker Images

### DIFF
--- a/.github/create-docker-release.yml
+++ b/.github/create-docker-release.yml
@@ -1,0 +1,22 @@
+name: Build and push VMware Event Router to Docker Hub
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source (master branch)
+        uses: actions/checkout@master
+        with:
+          ref: 'master'
+      - name: log in to Docker
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
+        run: echo "${DOCKER_SECRET}" | docker login -u "${DOCKER_USER}" --password-stdin
+      - name: test, build, tag and push image
+        run: cd vmware-event-router && make release


### PR DESCRIPTION
After a release is published, the corresponding Github event will
trigger this workflow to build and push the Docker images for the VMware
Event Router as per the Makefile target `make release`.

Github secrets (encrypted) for `DOCKER_USER` and `DOCKER_SECRET` are
used to authenticate. These secrets are not exposed through the UI and
not persisted after the workflow terminates as per the Github Actions
documentation.

Tested successfully in a fork of this repository:

![image](https://user-images.githubusercontent.com/15986659/81018250-74763880-8e64-11ea-890b-86ed4f67bb15.png)

> **Note:** Github (Actions) automatically hides sensitive information from the logs, e.g. secrets. The Docker password warning can be ignored as the Github Actions runner (using Microsoft Azure compliant VMs) will not be reused after a workflow run, i.e. each workflow runs in a fresh VM instance. ([Source](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners))

Signed-off-by: Michael Gasch <mgasch@vmware.com>