### PR TITLE
Remove unnecessary vmw:ExtraConfig from OVA

### DIFF
--- a/manual/add_ovf_properties.sh
+++ b/manual/add_ovf_properties.sh
@@ -13,11 +13,13 @@ if [ "$(uname)" == "Darwin" ]; then
     sed -i .bak2 "/    <\/vmw:BootOrderSection>/ r photon.xml" ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
     sed -i .bak3 '/^      <vmw:ExtraConfig ovf:required="false" vmw:key="nvram".*$/d' ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
     sed -i .bak4 "/^    <File ovf:href=\"${VEBA_APPLIANCE_NAME}-file1.nvram\".*$/d" ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
+    sed -i .bak5 '/vmw:ExtraConfig.*/d' ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
 else
     sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo">/g' ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
     sed -i "/    <\/vmw:BootOrderSection>/ r photon.xml" ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
     sed -i '/^      <vmw:ExtraConfig ovf:required="false" vmw:key="nvram".*$/d' ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
     sed -i "/^    <File ovf:href=\"${VEBA_APPLIANCE_NAME}-file1.nvram\".*$/d" ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
+    sed -i '/vmw:ExtraConfig.*/d' ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf
 fi
 
 ovftool ${OUTPUT_PATH}/${VEBA_APPLIANCE_NAME}/${VEBA_APPLIANCE_NAME}.ovf ${OUTPUT_PATH}/${FINAL_VEBA_APPLIANCE_NAME}.ova


### PR DESCRIPTION
> Summary

This change removes the following `<vmw:ExtraConfig ovf:required="false" vmw:key="virtualhw.productcompatibility" vmw:value="hosted"/>` entry as its automatically generated after a VM is exported. This setting is not needed but the impact is it generates a warning message which can be seen as an issue

<img width="1120" alt="Screen Shot 2020-05-07 at 1 44 05 PM" src="https://user-images.githubusercontent.com/602199/81343436-d94eb000-9069-11ea-9303-1df3a99d5681.png">

> Resolves

Closes: #123

> Testing

Deployed VEBA OVA using vSphere UI and ensure the following message `The OVF package contains advanced configuration options, which might pose a security risk. Review the advanced configuration options below. Click next to accept the advanced configuration options.` is no longer observed

Signed-off-by: William Lam <wlam@vmware.com>