### PR TITLE
Add Action to reject PRs against master

### DIFF
--- a/.github/workflows/protect-master.yml
+++ b/.github/workflows/protect-master.yml
@@ -1,0 +1,19 @@
+# Even though branch protection rules might be in place, this is an additional
+# safety net to protect against unwanted pull requests against "master"
+name: Protect Master Branch
+
+# This workflow is triggered on PRs to the master branch
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  protect:
+    name: Reject
+    runs-on: ubuntu-latest
+    # sanity check
+    if: github.event_name == 'pull_request' && github.base_ref == 'master'
+    steps:
+      - name: Must reject PR
+        run: exit 1


### PR DESCRIPTION
Even though branch protection rules might be in place, this is an
additional safety net to protect against unwanted pull requests against
`master`.

Should this action trigger, a corresponding failed check in the pull
request will indicate this visually.

Signed-off-by: Michael Gasch <mgasch@vmware.com>