### PR TITLE
Add Action for Event Router Unit Tests on PRs

### DIFF
--- a/.github/workflows/router-unit-tests.yml
+++ b/.github/workflows/router-unit-tests.yml
@@ -1,0 +1,23 @@
+name: VMware Event Router Unit Tests
+
+# triggered on PRs but only when changes inside vmware-event-router (sub)dir(s)
+on:
+  pull_request:
+    paths:
+      - 'vmware-event-router/**'
+
+# run all jobs with these defaults, unless specified otherwise
+defaults:
+  run:
+    shell: bash
+    working-directory: ./vmware-event-router
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@master
+      - name: run unit tests
+        run: make test
+          


### PR DESCRIPTION
This action is triggered on pull requests but only when there are
changes to the `vmware-event-router` directory, incl. sub-directories.

The action will run the in the `Makefile` specified unit tests for the
VMware Event Router.

Signed-off-by: Michael Gasch <mgasch@vmware.com>