### PR TITLE
Added proxy support for deployment scripts

### DIFF
--- a/test/deploy_veba_eventbridge_processor.sh
+++ b/test/deploy_veba_eventbridge_processor.sh
@@ -35,6 +35,11 @@ VEBA_AWS_EVENTBRIDGE_ACCESS_SECRET="FILL_ME_IN_PLEASE"
 VEBA_AWS_EVENTBRIDGE_EVENT_BUS="FILL_ME_IN_PLEASE"
 VEBA_AWS_EVENTBRIDGE_REGION="us-west-2"
 VEBA_AWS_EVENTBRIDGE_RULE_ARN="FILL_ME_IN_PLEASE"
+VEBA_HTTP_PROXY=""
+VEBA_HTTPS_PROXY=""
+VEBA_PROXY_USERNAME=""
+VEBA_PROXY_PASSWORD=""
+VEBA_NOPROXY=""
 
 ### DO NOT EDIT BEYOND HERE ###
 
@@ -54,6 +59,11 @@ VEBA_AWS_EVENTBRIDGE_RULE_ARN="FILL_ME_IN_PLEASE"
     --prop:guestinfo.dns=${VEBA_DNS} \
     --prop:guestinfo.domain=${VEBA_DNS_DOMAIN} \
     --prop:guestinfo.ntp=${VEBA_NTP} \
+    --prop:guestinfo.http_proxy=${VEBA_HTTP_PROXY} \
+    --prop:guestinfo.https_proxy=${VEBA_HTTPS_PROXY} \
+    --prop:guestinfo.proxy_username=${VEBA_PROXY_USERNAME} \
+    --prop:guestinfo.proxy_password=${VEBA_PROXY_PASSWORD} \
+    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \	
     --prop:guestinfo.root_password=${VEBA_OS_PASSWORD} \
     --prop:guestinfo.vcenter_server=${VEBA_VCENTER_SERVER} \
     --prop:guestinfo.vcenter_username=${VEBA_VCENTER_USER} \

--- a/test/deploy_veba_openfaas_processor.sh
+++ b/test/deploy_veba_openfaas_processor.sh
@@ -32,6 +32,11 @@ VEBA_VCENTER_PASS="VMware1!"
 VEBA_VCENTER_DISABLE_TLS="True"
 VEBA_OPENFAAS_PASS="VMware1!"
 VEBA_DOCKER_NETWORK="172.26.0.1/16"
+VEBA_HTTP_PROXY=""
+VEBA_HTTPS_PROXY=""
+VEBA_PROXY_USERNAME=""
+VEBA_PROXY_PASSWORD=""
+VEBA_NOPROXY=""
 
 ### DO NOT EDIT BEYOND HERE ###
 
@@ -51,6 +56,11 @@ VEBA_DOCKER_NETWORK="172.26.0.1/16"
     --prop:guestinfo.dns=${VEBA_DNS} \
     --prop:guestinfo.domain=${VEBA_DNS_DOMAIN} \
     --prop:guestinfo.ntp=${VEBA_NTP} \
+    --prop:guestinfo.http_proxy=${VEBA_HTTP_PROXY} \
+    --prop:guestinfo.https_proxy=${VEBA_HTTPS_PROXY} \
+    --prop:guestinfo.proxy_username=${VEBA_PROXY_USERNAME} \
+    --prop:guestinfo.proxy_password=${VEBA_PROXY_PASSWORD} \
+    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \	
     --prop:guestinfo.root_password=${VEBA_OS_PASSWORD} \
     --prop:guestinfo.vcenter_server=${VEBA_VCENTER_SERVER} \
     --prop:guestinfo.vcenter_username=${VEBA_VCENTER_USER} \


### PR DESCRIPTION
Added variables VEBA_HTTP_PROXY, VEBA_HTTPS_PROXY, VEBA_PROXY_USERNAME, VEBA_PROXY_PASSWORD, and VEBA_NOPROXY to the deployment shell scripts.

Tested with VEBA 0.4 deployed on vCenter 7.0. 

Signed-off-by: Patrick Kremer <pkremer@vmware.com>