### PR TITLE
Updating PagerDuty Fx container image name for consistency

### DIFF
--- a/examples/python/trigger-pagerduty-incident/README.MD
+++ b/examples/python/trigger-pagerduty-incident/README.MD
@@ -46,7 +46,7 @@ functions:
   pdinvoke-fn:
     lang: python3
     handler: ./handler
-    image: vmware/veba-pagerduty-invoke:latest
+    image: vmware/veba-python-pagerduty:latest
     environment:
       write_debug: true #function writes verbose entries to the log when set to true, also requires combine_output to be set to false to avoid debug messages from showing up in the response
       read_debug: true

--- a/examples/python/trigger-pagerduty-incident/stack.yml
+++ b/examples/python/trigger-pagerduty-incident/stack.yml
@@ -5,7 +5,7 @@ functions:
   pdinvoke-fn:
     lang: python3
     handler: ./handler
-    image: vmware/veba-pagerduty-invoke:latest
+    image: vmware/veba-python-pagerduty:latest
     environment:
       write_debug: true
       read_debug: true


### PR DESCRIPTION
Updating container image from 'veba-pagerduty-invoke' to 'veba-python-pagerduty' for consistency 

Signed-off-by: pksrc <kandasamyp@vmware.com>