### PR TITLE
Added recommendation to add appliance IP to NO_PROXY

### DIFF
--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -53,7 +53,7 @@
         </Property>
         <Property ovf:key="guestinfo.no_proxy" ovf:type="string" ovf:userConfigurable="true">
             <Label>No Proxy</Label>
-            <Description>No Proxy for e.g. your internal domain suffix. Comma separated (localhost, 127.0.0.1, domain.local)</Description>
+            <Description>No Proxy for e.g. your internal domain suffix. Adding the appliance IP address is recommended. Comma separated (localhost, 127.0.0.1, domain.local)</Description>
         </Property>
       <Category>OS Credentials</Category>
         <Property ovf:key="guestinfo.root_password" ovf:password="true" ovf:type="string" ovf:userConfigurable="true" ovf:value="">


### PR DESCRIPTION
Added "Adding the appliance IP address is recommended." text to the No Proxy instructions in the OVA. This will 

Tested by executing an OVA build and navigating to the no_proxy input section - screenshot below:
![no-proxy-template](https://user-images.githubusercontent.com/29929717/81872702-e1ae5b80-953f-11ea-94d2-a511c56be719.png)

Signed-off-by: Patrick Kremer <pkremer@vmware.com>