### PR TITLE
Fixed typo in processing ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS variable

### DIFF
--- a/files/setup-05-event-processor.sh
+++ b/files/setup-05-event-processor.sh
@@ -27,7 +27,7 @@ if [ "${EVENT_PROCESSOR_TYPE}" == "AWS EventBridge" ]; then
 
 	ESCAPED_AWS_EVENTBRIDGE_ACCESS_KEY=$(echo -n ${AWS_EVENTBRIDGE_ACCESS_KEY} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
 	ESCAPED_AWS_EVENTBRIDGE_ACCESS_SECRET=$(echo -n ${AWS_EVENTBRIDGE_ACCESS_SECRET} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
-	ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS=$(echo -n ${VCENTER_USEAWS_EVENTBRIDGE_EVENT_BUSNAME} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
+	ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS=$(echo -n ${AWS_EVENTBRIDGE_EVENT_BUS} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
 	ESCAPED_AWS_EVENTBRIDGE_RULE_ARN=$(echo -n ${AWS_EVENTBRIDGE_RULE_ARN} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
 
     cat > ${EVENT_ROUTER_CONFIG} << __AWS_EVENTBRIDGE_PROCESSOR__


### PR DESCRIPTION
> Summary

It was identified that when deploying VEBA `v0.4.0` using the AWS EventBridge processor, that the system looks to hang and never completes. This change fixes a typo in processing the `ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS` variable which causes the event processor script to fail (by design)

Here's snippet from the debug logs:
```
/root/setup/setup-05-event-processor.sh: line 30: VCENTER_USEAWS_EVENTBRIDGE_EVENT_BUSNAME: unbound variable
++ ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS=
```

> Resolves

Closes: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/143

> Testing

Successfully deployed pre-release (v0.4.1) of VEBA using AWS EventBridge and confirm VEBA DCUI is properly loaded and no longer hangs. 


Signed-off-by: William Lam <wlam@vmware.com>