### PR TITLE
Introduce Error struct in processor

### DIFF
--- a/vmware-event-router/internal/processor/aws_event_bridge.go
+++ b/vmware-event-router/internal/processor/aws_event_bridge.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"sync"
@@ -176,8 +177,9 @@ func NewAWSEventBridgeProcessor(ctx context.Context, cfg connection.Config, sour
 func (awsEventBridge *awsEventBridgeProcessor) Process(moref types.ManagedObjectReference, baseEvent []types.BaseEvent) error {
 	batchInput, err := awsEventBridge.createPutEventsInput(baseEvent)
 	if err != nil {
-		awsEventBridge.Printf("could not create PutEventsInput for event(s): %v", err)
-		return nil
+		errMsg := fmt.Errorf("could not create PutEventsInput for event(s): %v", err)
+		awsEventBridge.Printf(errMsg.Error())
+		return NewError(ProviderAWS, errMsg).Error()
 	}
 
 	// nothing to send

--- a/vmware-event-router/internal/processor/aws_event_bridge.go
+++ b/vmware-event-router/internal/processor/aws_event_bridge.go
@@ -178,7 +178,7 @@ func (awsEventBridge *awsEventBridgeProcessor) Process(moref types.ManagedObject
 	batchInput, err := awsEventBridge.createPutEventsInput(baseEvent)
 	if err != nil {
 		errMsg := fmt.Errorf("could not create PutEventsInput for event(s): %v", err)
-		awsEventBridge.Printf(errMsg.Error())
+		awsEventBridge.Println(errMsg)
 		return processorError(ProviderAWS, errMsg)
 	}
 

--- a/vmware-event-router/internal/processor/aws_event_bridge.go
+++ b/vmware-event-router/internal/processor/aws_event_bridge.go
@@ -179,7 +179,7 @@ func (awsEventBridge *awsEventBridgeProcessor) Process(moref types.ManagedObject
 	if err != nil {
 		errMsg := fmt.Errorf("could not create PutEventsInput for event(s): %v", err)
 		awsEventBridge.Printf(errMsg.Error())
-		return NewError(ProviderAWS, errMsg).Error()
+		return processorError(ProviderAWS, errMsg)
 	}
 
 	// nothing to send

--- a/vmware-event-router/internal/processor/processor.go
+++ b/vmware-event-router/internal/processor/processor.go
@@ -22,12 +22,11 @@ type Error struct {
 	err       error
 }
 
-// NewError constructs Error structure
-func NewError(processor string, err error) *Error {
+func processorError(processor string, err error) error {
 	return &Error{
 		processor: processor,
 		err:       err,
 	}
 }
 
-func (e *Error) Error() error { return fmt.Errorf("%s: %s", e.processor, e.err.Error()) }
+func (e *Error) Error() string { return fmt.Sprintf("%s: %s", e.processor, e.err.Error()) }

--- a/vmware-event-router/internal/processor/processor.go
+++ b/vmware-event-router/internal/processor/processor.go
@@ -1,6 +1,8 @@
 package processor
 
 import (
+	"fmt"
+
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -11,3 +13,21 @@ import (
 type Processor interface {
 	Process(types.ManagedObjectReference, []types.BaseEvent) error
 }
+
+// Error struct contains the generic error content used by the processors
+// it extends the simple error by providing context which processor gave
+// the error
+type Error struct {
+	processor string
+	err       error
+}
+
+// NewError constructs Error structure
+func NewError(processor string, err error) *Error {
+	return &Error{
+		processor: processor,
+		err:       err,
+	}
+}
+
+func (e *Error) Error() error { return fmt.Errorf("%s: %s", e.processor, e.err.Error()) }

--- a/vmware-event-router/internal/processor/processor_test.go
+++ b/vmware-event-router/internal/processor/processor_test.go
@@ -1,0 +1,36 @@
+package processor
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_processor_error(t *testing.T) {
+	tests := []struct {
+		title       string
+		provider    string
+		errMessage  error
+		expectedErr string
+	}{
+		{
+			title:       "Event Bridge unable to process VmPoweredOnEvent",
+			provider:    ProviderAWS,
+			errMessage:  fmt.Errorf("could not create PutEventsInput for event(s): VmPoweredOnEvent"),
+			expectedErr: "aws_event_bridge: could not create PutEventsInput for event(s): VmPoweredOnEvent",
+		},
+		{
+			title:       "OpenFaaS processor unable to handle VmPoweredOnEvent",
+			provider:    ProviderOpenFaaS,
+			errMessage:  fmt.Errorf("error handling event: VmPoweredOnEvent"),
+			expectedErr: "openfaas: error handling event: VmPoweredOnEvent",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			actualErr := processorError(test.provider, test.errMessage)
+			if actualErr.Error() != test.expectedErr {
+				t.Errorf("Expected error: %s got: %s", test.expectedErr, actualErr.Error())
+			}
+		})
+	}
+}

--- a/vmware-event-router/internal/processor/processor_test.go
+++ b/vmware-event-router/internal/processor/processor_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package processor
 
 import (


### PR DESCRIPTION
Introducing Error struct in processor package next to the
interface, to be used by the Process method to extend the
errors with more context by providing the name of the
processor

Signed-off-by: Martin Dekov <mvdekov@gmail.com>