### PR TITLE
Added enable SSH option to OVA install

### DIFF
--- a/files/setup-01-os.sh
+++ b/files/setup-01-os.sh
@@ -6,8 +6,13 @@
 
 set -euo pipefail
 
-systemctl disable sshd
-systemctl stop sshd
+if [ "${ENABLE_SSH}" == "true" ]; then
+    systemctl enable sshd
+    systemctl start sshd
+else
+    systemctl disable sshd
+    systemctl stop sshd
+fi
 
 echo -e "\e[92mConfiguring OS Root password ..." > /dev/console
 echo "root:${ROOT_PASSWORD}" | /usr/sbin/chpasswd

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -19,6 +19,7 @@ PROXY_USERNAME=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.pr
 PROXY_PASSWORD=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.proxy_password" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')
 NO_PROXY=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.no_proxy" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')
 ROOT_PASSWORD=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.root_password" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')
+ENABLE_SSH=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.enable_ssh" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}' | tr '[:upper:]' '[:lower:]')
 VCENTER_SERVER=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.vcenter_server" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')
 VCENTER_USERNAME=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.vcenter_username" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')
 VCENTER_PASSWORD=$(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "guestinfo.vcenter_password" | awk -F 'oe:value="' '{print $2}' | awk -F '"' '{print $1}')

--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -60,6 +60,10 @@
             <Label>Root Password</Label>
             <Description>Password to login in as root. Please use a secure password</Description>
         </Property>
+        <Property ovf:key="guestinfo.enable_ssh" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="false">
+            <Label>Enable SSH</Label>
+            <Description>Automatically start SSH daemon</Description>
+        </Property>
      <Category>vSphere</Category>
         <Property ovf:key="guestinfo.vcenter_server" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
             <Label>vCenter Server</Label>

--- a/test/deploy_veba_eventbridge_processor.sh
+++ b/test/deploy_veba_eventbridge_processor.sh
@@ -23,6 +23,7 @@ VEBA_DNS="192.168.30.1"
 VEBA_DNS_DOMAIN="primp-industries.com"
 VEBA_NTP="pool.ntp.org"
 VEBA_OS_PASSWORD="VMware1!"
+VEBA_ENABLE_SSH="False"
 VEBA_NETWORK="VM Network"
 VEBA_DATASTORE="sm-vsanDatastore"
 VEBA_DEBUG="True"
@@ -40,6 +41,7 @@ VEBA_HTTPS_PROXY=""
 VEBA_PROXY_USERNAME=""
 VEBA_PROXY_PASSWORD=""
 VEBA_NOPROXY=""
+
 
 ### DO NOT EDIT BEYOND HERE ###
 
@@ -63,8 +65,9 @@ VEBA_NOPROXY=""
     --prop:guestinfo.https_proxy=${VEBA_HTTPS_PROXY} \
     --prop:guestinfo.proxy_username=${VEBA_PROXY_USERNAME} \
     --prop:guestinfo.proxy_password=${VEBA_PROXY_PASSWORD} \
-    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \	
+    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \
     --prop:guestinfo.root_password=${VEBA_OS_PASSWORD} \
+    --prop:guestinfo.enable_ssh=${VEBA_ENABLE_SSH} \
     --prop:guestinfo.vcenter_server=${VEBA_VCENTER_SERVER} \
     --prop:guestinfo.vcenter_username=${VEBA_VCENTER_USER} \
     --prop:guestinfo.vcenter_password=${VEBA_VCENTER_PASS} \

--- a/test/deploy_veba_openfaas_processor.sh
+++ b/test/deploy_veba_openfaas_processor.sh
@@ -5,7 +5,7 @@
 # Sample Shell Script to test deployment of VEBA w/OpenFaaS Processor
 
 OVFTOOL_BIN_PATH="/Applications/VMware OVF Tool/ovftool"
-VEBA_OVA="../output-vmware-iso/vCenter_Event_Broker_Appliance_0.4.0.ova"
+VEBA_OVA="../output-vmware-iso/vCenter_Event_Broker_Appliance_0.4.0-beta.ova"
 
 # vCenter
 DEPLOYMENT_TARGET_ADDRESS="192.168.30.200"
@@ -15,7 +15,7 @@ DEPLOYMENT_TARGET_DATACENTER="Primp-Datacenter"
 DEPLOYMNET_TARGET_CLUSTER="Supermicro-Cluster"
 
 VEBA_NAME="VEBA-TEST-OPENFAAS-PROCESSOR"
-VEBA_IP="192.168.30.170"
+VEBA_IP="192.168.130.170"
 VEBA_HOSTNAME="veba.primp-industries.com"
 VEBA_PREFIX="24 (255.255.255.0)"
 VEBA_GW="192.168.30.1"
@@ -23,6 +23,7 @@ VEBA_DNS="192.168.30.1"
 VEBA_DNS_DOMAIN="primp-industries.com"
 VEBA_NTP="pool.ntp.org"
 VEBA_OS_PASSWORD="VMware1!"
+VEBA_ENABLE_SSH="True"
 VEBA_NETWORK="VM Network"
 VEBA_DATASTORE="sm-vsanDatastore"
 VEBA_DEBUG="True"
@@ -60,8 +61,9 @@ VEBA_NOPROXY=""
     --prop:guestinfo.https_proxy=${VEBA_HTTPS_PROXY} \
     --prop:guestinfo.proxy_username=${VEBA_PROXY_USERNAME} \
     --prop:guestinfo.proxy_password=${VEBA_PROXY_PASSWORD} \
-    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \	
+    --prop:guestinfo.no_proxy=${VEBA_NOPROXY} \
     --prop:guestinfo.root_password=${VEBA_OS_PASSWORD} \
+    --prop:guestinfo.enable_ssh=${VEBA_ENABLE_SSH} \
     --prop:guestinfo.vcenter_server=${VEBA_VCENTER_SERVER} \
     --prop:guestinfo.vcenter_username=${VEBA_VCENTER_USER} \
     --prop:guestinfo.vcenter_password=${VEBA_VCENTER_PASS} \


### PR DESCRIPTION
Add an Enable SSH checkbox in the OVA GUI. Update the automation scripts in /test to also support enabling SSH on deployment. Fixed issues in the automation scripts caused by unexpected spaces added by Windows - edited them in Linux instead.

Testing:
1. Deploy from UI, check SSH box. Expected behavior: SSH running on boot. Result: Success
2. Deploy from UI, uncheck SSH box. Expected behavior: SSH not running on boot. Result: Success
3. Deploy from deploy_veba_openfaas_processor.sh, VEBA_ENABLE_SSH="True". Expected behavior: SSH running on boot. Result: Success
4. Deploy from deploy_veba_openfaas_processor.sh, VEBA_ENABLE_SSH="False": SSH running on boot. Result: Success


 
Signed-off-by: Patrick Kremer <pkremer@vmware.com>