### PR TITLE
Add Action to block PR merge when title is WIP

### DIFF
--- a/.github/workflows/check-wip-pr.yml
+++ b/.github/workflows/check-wip-pr.yml
@@ -1,0 +1,14 @@
+# Perform "exit 1" if PR title starts with "WIP" to block accidental merges
+name: Check "WIP" in PR Title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  WIP:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, 'WIP')
+    steps:
+      - name: Must Exit
+        run: exit 1


### PR DESCRIPTION
Perform `exit 1` if PR title starts with "WIP" to block accidental
merges of pull requests which are work in progress. Matches any title
which starts with "WIP", e.g. including "WIP:". Gets triggered on PR
open/edited/reopened and when (new) commits are (force) pushed.

Signed-off-by: Michael Gasch <mgasch@vmware.com>