### PR TITLE
install gems only for the user, and set a vendor path for bundle use

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ The website is hosted using [Github Pages](https://help.github.com/en/github/wor
 └── Gemfile                   > Plugins required for the website to be built by Jekyll
 ```
 
-In order for Jekyll to process the MD files and render them as html, you'll need to add the below to the beginning of the each MD file. 
+In order for Jekyll to process the MD files and render them as html, you'll need to add the below to the beginning of the each MD file.
 
 ```yaml
 ---
@@ -59,8 +59,10 @@ Install the following for an easy to use dev environment:
 ```bash
 brew install rbenv
 rbenv install 2.6.3
-gem install bundler --user-install
+gem install bundler
 ```
+
+*Note: if you hit a permissions error for the `gem install bundler` follow advice from the [bundler docs](https://bundler.io/doc/troubleshooting.html#permission-denied-when-installing-bundler)*
 
 ### Dependencies for Linux
 If you are running a build on Ubuntu you will need the following packages:
@@ -82,14 +84,13 @@ This mirrors the plug-ins used by GitHub Pages on your local machine including J
 ```bash
 git clone git@github.com:vmware-samples/vcenter-event-broker-appliance.git
 cd vcenter-event-broker-appliance/docs
-bundle config set path '~/.vendor/bundle'
 bundle install
 ```
 
 * Serve the site and watch for markup/sass changes `jekyll serve --livereload --incremental`. You may need to run `bundle exec jekyll serve --livereload --incremental`.
 * View your website at http://127.0.0.1:4000/
 * Commit any changes and push everything to your fork.
-* Once you're ready, submit a PR of your changes. 
+* Once you're ready, submit a PR of your changes.
 
 ## Troubleshooting
 * If you don't see your updates reflected on the website when running locally, try the following steps

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Install the following for an easy to use dev environment:
 ```bash
 brew install rbenv
 rbenv install 2.6.3
-gem install bundler
+gem install bundler --user-install
 ```
 
 ### Dependencies for Linux
@@ -82,6 +82,7 @@ This mirrors the plug-ins used by GitHub Pages on your local machine including J
 ```bash
 git clone git@github.com:vmware-samples/vcenter-event-broker-appliance.git
 cd vcenter-event-broker-appliance/docs
+bundle config set path '~/.vendor/bundle'
 bundle install
 ```
 


### PR DESCRIPTION
Using a mac, I needed to do this to test a change in the docs.

* `gem ... --user-install` to avoid using sudo
* use a vendor dir that is outside of the docs tree

Signed-off-by: Tom Scanlan <tscanlan@vmware.com>