### PR TITLE
Add FQDN hint to hostname description field

### DIFF
--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -8,7 +8,7 @@
       <Category>Networking</Category>
         <Property ovf:key="guestinfo.hostname" ovf:type="string" ovf:userConfigurable="true">
             <Label>Hostname</Label>
-            <Description>Hostname of system</Description>
+            <Description>Hostname (FQDN) of system</Description>
         </Property>
         <Property ovf:key="guestinfo.ipaddress" ovf:type="string" ovf:userConfigurable="true">
             <Label>IP Address</Label>


### PR DESCRIPTION
Signed-off-by: Robert Guske <rguske@vmware.com>

Add a FQDN hint to the _Hostname_ description field of the OVF template to make it more obvious for the user to enter the Fully-Qualified-Domain-Name of the appliance here.

Example:
![CapturFiles-20200520_101824](https://user-images.githubusercontent.com/31652019/82494603-227f1500-9aea-11ea-8547-a9edeeddc120.jpg)
