### PR TITLE
Add VEBA build-of-materials (BOM) JSON

### DIFF
--- a/photon.json
+++ b/photon.json
@@ -146,6 +146,11 @@
       "type": "file",
       "source": "files/veba-dcui",
       "destination": "/usr/bin/veba-dcui"
+    },
+    {
+      "type": "file",
+      "source": "veba-bom.json",
+      "destination": "/root/config/veba-bom.json"
     }
   ],
   "post-processors": [

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -1,0 +1,112 @@
+{
+    "antrea" : {
+        "version" : "v0.6.0",
+        "containers" : [
+                {
+                    "name": "antrea-ubuntu",
+                    "version" : "v0.6.0"
+                }
+            ]
+    },
+    "contour" : {
+        "version" : "v1.0.0-beta.1",
+        "containers" : [
+            {
+                "name": "projectcontour/contour",
+                "version": "v1.0.0-beta.1"
+            },
+            {
+                "name": "envoyproxy/envoy",
+                "version": "v1.11.1"
+            }
+        ]
+    },
+    "kubernetes" : {
+        "version" : "v1.14.9",
+        "containers": [
+            {
+                "name": "k8s.gcr.io/kube-apiserver",
+                "version": "v1.14.9"
+            },
+            {
+                "name": "k8s.gcr.io/kube-controller-manager",
+                "version": "v1.14.9"
+            },
+            {
+                "name": "k8s.gcr.io/kube-scheduler",
+                "version": "v1.14.9"
+            },
+            {
+                "name": "k8s.gcr.io/kube-proxy",
+                "version": "v1.14.9"
+            },
+            {
+                "name" : "k8s.gcr.io/pause",
+                "version" : "3.1"
+            },
+            {
+                "name" : "k8s.gcr.io/etcd",
+                "version" : "3.3.10"
+            },
+            {
+                "name" : "k8s.gcr.io/coredns",
+                "version" : "1.3.1"
+            }
+        ]
+    },
+    "openfaas" : {
+        "version" : "0.9.2",
+        "containers" : [
+            {
+                "name" : "openfaas/faas-netes",
+                "version" : "0.9.0"
+            },
+            {
+                "name" : "openfaas/gateway",
+                "version" : "0.17.4"
+            },
+            {
+                "name" : "openfaas/basic-auth-plugin",
+                "version" : "0.17.0"
+            },
+            {
+                "name" : "openfaas/queue-worker",
+                "version" : "0.8.0"
+            },
+            {
+                "name" : "openfaas/faas-idler",
+                "version" : "0.2.1"
+            },
+            {
+                "name" : "prom/prometheus",
+                "version" : "v2.11.0"
+            },
+            {
+                "name" : "prom/alertmanager",
+                "version" : "v0.18.0"
+            },
+            {
+                "name" : "nats-streaming",
+                "version" : "0.11.2"
+            }
+        ]
+    },
+    "tinywww" :{
+        "version" : "latest",
+        "containers" : [
+            {
+                "name" : "embano1/tinywww",
+                "version" : "latest"
+            }
+        ]
+    },
+    "vmware-event-router" : {
+        "version" : "0.9.2",
+        "containers" : [
+            {
+                "name": "vmware/veba-event-router",
+                "version": "v4.0.0"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This change introduces a `veba-bom.json` file which contains the build of materials (BOM) for all components of VEBA including the individual containers and their respective versions. 

This can be used for informational purposes but will also serve as a single source of truth for components and their version of software when VEBA is built. A copy of the BOM will also be pushed into the appliance and stored under `/root/config/veba-bom.json` a reference point. 

Signed-off-by: William Lam <wlam@vmware.com>