### PR TITLE
Refactoring VEBA component reference + updating components to latest version 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,18 @@
 
 set -euo pipefail
 
+VEBA_BOM_FILE=veba-bom.json
+
+if [ ! -e ${VEBA_BOM_FILE} ]; then
+    echo "Unable to locate veba-bom.json in current directory which is required"
+    exit 1
+fi
+
+#command -v jqw > /dev/null 2>&1
+if [ ! -e /usr/local/bin/jq ]; then
+    echo "jq utility is not installed on this system"
+    exit 1
+fi
 
 if [ $# -ne 1 ]; then
     echo -e "\n\tUsage: $0 [master|release]\n"
@@ -17,12 +29,14 @@ fi
 
 rm -f output-vmware-iso/*.ova
 
+VEBA_VERSION_FROM_BOM=$(jq -r < ${VEBA_BOM_FILE} '.veba.version')
+
 if [ "$1" == "release" ]; then
     echo "Building VEBA OVA release ..."
-    packer build -var "VEBA_VERSION=$(cat VERSION)-release" -var "VEBA_COMMIT=$(git rev-parse --short HEAD)" -var-file=photon-builder.json -var-file=photon-version.json photon.json
+    packer build -var "VEBA_VERSION=${VEBA_VERSION_FROM_BOM}-release" -var "VEBA_COMMIT=$(git rev-parse --short HEAD)" -var-file=photon-builder.json -var-file=photon-version.json photon.json
 elif [ "$1" == "master" ]; then
     echo "Building VEBA OVA master ..."
-    packer build -var "VEBA_VERSION=$(cat VERSION)" -var "VEBA_COMMIT=$(git rev-parse --short HEAD)" -var-file=photon-builder.json -var-file=photon-version.json photon.json
+    packer build -var "VEBA_VERSION=${VEBA_VERSION_FROM_BOM}" -var "VEBA_COMMIT=$(git rev-parse --short HEAD)" -var-file=photon-builder.json -var-file=photon-version.json photon.json
 else
     echo -e "\nPlease specify release or master to build ...\n"
 fi

--- a/files/kubeconfig.yml
+++ b/files/kubeconfig.yml
@@ -1,6 +1,0 @@
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: InitConfiguration
----
-apiVersion: kubeadm.k8s.io/v1beta1
-kind: ClusterConfiguration
-kubernetesVersion: v1.14.9

--- a/files/setup-04-kubernetes.sh
+++ b/files/setup-04-kubernetes.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+VEBA_BOM_FILE=/root/config/veba-bom.json
+
 echo -e "\e[92mStarting Docker ..." > /dev/console
 systemctl daemon-reload
 systemctl start docker.service
@@ -20,14 +22,19 @@ if [ -z "${POD_NETWORK_CIDR}" ]; then
     POD_NETWORK_CIDR="10.16.0.0/16"
 fi
 
-cat >> /root/config/kubeconfig.yml << EOF
-
-networking:
-  podSubnet: ${POD_NETWORK_CIDR}
-EOF
-
 # Setup k8s
 echo -e "\e[92mSetting up k8s ..." > /dev/console
+K8S_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["kubernetes"].version')
+cat > /root/config/kubeconfig.yml << __EOF__
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: ${K8S_VERSION}
+networking:
+  podSubnet: ${POD_NETWORK_CIDR}
+__EOF__
 
 echo -e "\e[92mDeloying kubeadm ..." > /dev/console
 HOME=/root

--- a/files/setup-04-kubernetes.sh
+++ b/files/setup-04-kubernetes.sh
@@ -26,10 +26,10 @@ fi
 echo -e "\e[92mSetting up k8s ..." > /dev/console
 K8S_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["kubernetes"].version')
 cat > /root/config/kubeconfig.yml << __EOF__
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 ---
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 kubernetesVersion: ${K8S_VERSION}
 networking:

--- a/photon-version.json
+++ b/photon-version.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.4.0",
   "description": "Photon Build for vCenter Event Broker Appliance",
   "vm_name": "vCenter_Event_Broker_Appliance",
   "iso_checksum": "f6619bcff94cef63d0d6d7ead7dd3878816ebfa6a1ef5717175bb0d08d4ccc719e4ec7daa7db3c5dc07ea3547fc24412b4dc6827a4ac332ada9d5bfc842c4229",

--- a/photon.json
+++ b/photon.json
@@ -62,6 +62,11 @@
       ]
     },
     {
+      "type": "file",
+      "source": "veba-bom.json",
+      "destination": "/root/config/veba-bom.json"
+    },
+    {
       "type": "shell",
       "environment_vars": [
         "VEBA_VERSION={{ user `VEBA_VERSION` }}"
@@ -136,11 +141,6 @@
       "type": "file",
       "source": "files/tinywww-debug.yml",
       "destination": "/root/config/tinywww-debug.yml"
-    },
-    {
-      "type": "file",
-      "source": "files/kubeconfig.yml",
-      "destination": "/root/config/kubeconfig.yml"
     },
     {
       "type": "file",

--- a/photon.json
+++ b/photon.json
@@ -51,6 +51,15 @@
   "provisioners": [
     {
       "type": "shell",
+      "inline": ["mkdir -p /root/config"]
+    },
+    {
+      "type": "file",
+      "source": "veba-bom.json",
+      "destination": "/root/config/veba-bom.json"
+    },
+    {
+      "type": "shell",
       "environment_vars": [
         "VEBA_VERSION={{ user `VEBA_VERSION` }}",
         "VEBA_COMMIT={{ user `VEBA_COMMIT` }}"
@@ -60,11 +69,6 @@
         "scripts/photon-settings.sh",
         "scripts/photon-docker.sh"
       ]
-    },
-    {
-      "type": "file",
-      "source": "veba-bom.json",
-      "destination": "/root/config/veba-bom.json"
     },
     {
       "type": "shell",

--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -4,52 +4,42 @@
 
 echo '> Pre-Downloading Kubeadm Docker Containers'
 
-CONTAINERS=(
-k8s.gcr.io/kube-apiserver:v1.14.9
-k8s.gcr.io/kube-controller-manager:v1.14.9
-k8s.gcr.io/kube-scheduler:v1.14.9
-k8s.gcr.io/kube-proxy:v1.14.9
-k8s.gcr.io/pause:3.1
-k8s.gcr.io/etcd:3.3.10
-k8s.gcr.io/coredns:1.3.1
-antrea/antrea-ubuntu:v0.6.0
-embano1/tinywww:latest
-projectcontour/contour:v1.0.0-beta.1
-openfaas/faas-netes:0.9.0
-openfaas/gateway:0.17.4
-openfaas/basic-auth-plugin:0.17.0
-openfaas/queue-worker:0.8.0
-openfaas/faas-idler:0.2.1
-envoyproxy/envoy:v1.11.1
-prom/prometheus:v2.11.0
-prom/alertmanager:v0.18.0
-nats-streaming:0.11.2
-vmware/veba-event-router:${VEBA_VERSION}
-)
+VEBA_BOM_FILE=/root/config/veba-bom.json
 
-for i in ${CONTAINERS[@]};
+for component_name in $(jq '. | keys | .[]' ${VEBA_BOM_FILE});
 do
-	docker pull $i
+    if [ $component_name != "\"veba\"" ]; then
+        for i in $(jq ".$component_name.containers | keys | .[]" ${VEBA_BOM_FILE}); do
+            value=$(jq -r ".$component_name.containers[$i]" ${VEBA_BOM_FILE});
+            container_name=$(jq -r '.name' <<< "$value");
+            container_version=$(jq -r '.version' <<< "$value");
+            docker pull "$container_name:$container_version"
+        done
+    fi
 done
 
 mkdir -p /root/download && cd /root/download
 
 echo '> Downloading FaaS-Netes...'
+OPENFAAS_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["openfaas"].version')
 git clone https://github.com/openfaas/faas-netes
 cd faas-netes
-git checkout 0.9.2
+git checkout ${OPENFAAS_VERSION}
 sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' yaml/*.yml
 cd ..
 
 echo '> Downloading Contour...'
+CONTOUR_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["contour"].version')
 git clone https://github.com/projectcontour/contour.git
 cd contour
-git checkout v1.0.0-beta.1
+git checkout ${CONTOUR_VERSION}
 sed -i '/^---/i \      dnsPolicy: ClusterFirstWithHostNet\n      hostNetwork: true' examples/contour/03-envoy.yaml
 sed -i 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' examples/contour/*.yaml
 cd ..
 
 echo '> Downloading Antrea...'
-wget https://github.com/vmware-tanzu/antrea/releases/download/v0.6.0/antrea.yml -O /root/download/antrea.yml
-sed -i 's/image: antrea\/antrea-ubuntu:.*/image: antrea\/antrea-ubuntu:v0.6.0/g' /root/download/antrea.yml
+ANTREA_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["antrea"].version')
+ANTREA_CONTAINER_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["antrea"].containers' | jq -r '.[] | select(.name | contains("antrea/antrea-ubuntu")).version')
+wget https://github.com/vmware-tanzu/antrea/releases/download/${ANTREA_VERSION}/antrea.yml -O /root/download/antrea.yml
+sed -i "s/image: antrea\/antrea-ubuntu:.*/image: antrea\/antrea-ubuntu:${ANTREA_CONTAINER_VERSION}/g" /root/download/antrea.yml
 sed -i '/image:.*/i \        imagePullPolicy: IfNotPresent' /root/download/antrea.yml

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -25,7 +25,8 @@ tdnf install -y \
   unzip \
   awk \
   tar \
-  kubernetes-kubeadm
+  kubernetes-kubeadm \
+  jq
 
 echo '> Creating directory for setup scripts and configuration files'
 mkdir -p /root/setup

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -8,12 +8,13 @@
 
 echo '> vCenter Event Broker Appliance Settings...'
 
+VEBA_BOM_FILE=/root/config/veba-bom.json
+
 echo '> Disable IPv6'
 echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
 
 echo '> Applying latest Updates...'
 tdnf -y update
-#tdnf upgrade linux-esx
 
 echo '> Installing Additional Packages...'
 tdnf install -y \
@@ -25,12 +26,26 @@ tdnf install -y \
   unzip \
   awk \
   tar \
-  kubernetes-kubeadm \
   jq
+
+echo '> Adding K8s Repo'
+curl -L https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg -o /etc/pki/rpm-gpg/GOOGLE-RPM-GPG-KEY
+rpm --import /etc/pki/rpm-gpg/GOOGLE-RPM-GPG-KEY
+cat > /etc/yum.repos.d/kubernetes.repo << EOF
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/GOOGLE-RPM-GPG-KEY
+EOF
+K8S_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["kubernetes"].version' | sed 's/v//g')
+# Ensure kubelet is updated to the latest desired K8s version
+tdnf install -y kubelet-${K8S_VERSION} kubectl-${K8S_VERSION} kubeadm-${K8S_VERSION}
 
 echo '> Creating directory for setup scripts and configuration files'
 mkdir -p /root/setup
-mkdir -p /root/config
 
 echo '> Creating tools.conf to prioritize eth0 interface...'
 cat > /etc/vmware-tools/tools.conf << EOF

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -1,118 +1,109 @@
 {
-    "veba" : {
-        "version" : "v0.4.0"
+    "veba": {
+        "version": "v0.4.0"
     },
-    "antrea" : {
-        "version" : "v0.6.0",
-        "containers" : [
-                {
-                    "name": "antrea/antrea-ubuntu",
-                    "version" : "v0.6.0"
-                }
-        ]
+    "antrea": {
+        "version": "v0.6.0",
+        "containers": [{
+            "name": "antrea/antrea-ubuntu",
+            "version": "v0.6.0"
+        }]
     },
-    "contour" : {
-        "version" : "v1.0.0-beta.1",
-        "containers" : [
-            {
+    "contour": {
+        "version": "v1.4.0",
+        "containers": [{
                 "name": "projectcontour/contour",
-                "version": "v1.0.0-beta.1"
+                "version": "v1.4.0"
             },
             {
                 "name": "envoyproxy/envoy",
-                "version": "v1.11.1"
+                "version": "v1.14.1"
             }
         ]
     },
-    "kubernetes" : {
-        "version" : "v1.14.9",
-        "containers": [
-            {
+    "kubernetes": {
+        "version": "v1.18.3",
+        "containers": [{
                 "name": "k8s.gcr.io/kube-apiserver",
-                "version": "v1.14.9"
+                "version": "v1.18.3"
             },
             {
                 "name": "k8s.gcr.io/kube-controller-manager",
-                "version": "v1.14.9"
+                "version": "v1.18.3"
             },
             {
                 "name": "k8s.gcr.io/kube-scheduler",
-                "version": "v1.14.9"
+                "version": "v1.18.3"
             },
             {
                 "name": "k8s.gcr.io/kube-proxy",
-                "version": "v1.14.9"
+                "version": "v1.18.3"
             },
             {
-                "name" : "k8s.gcr.io/pause",
-                "version" : "3.1"
+                "name": "k8s.gcr.io/pause",
+                "version": "3.2"
             },
             {
-                "name" : "k8s.gcr.io/etcd",
-                "version" : "3.3.10"
+                "name": "k8s.gcr.io/etcd",
+                "version": "3.4.3-0"
             },
             {
-                "name" : "k8s.gcr.io/coredns",
-                "version" : "1.3.1"
+                "name": "k8s.gcr.io/coredns",
+                "version": "1.6.7"
             }
         ]
     },
-    "openfaas" : {
-        "version" : "0.9.2",
-        "containers" : [
-            {
-                "name" : "openfaas/faas-netes",
-                "version" : "0.9.0"
+    "openfaas": {
+        "version": "0.10.5",
+        "containers": [{
+                "name": "openfaas/faas-netes",
+                "version": "0.10.3"
             },
             {
-                "name" : "openfaas/gateway",
-                "version" : "0.17.4"
+                "name": "openfaas/gateway",
+                "version": "0.18.17"
             },
             {
-                "name" : "openfaas/basic-auth-plugin",
-                "version" : "0.17.0"
+                "name": "openfaas/basic-auth-plugin",
+                "version": "0.18.17"
             },
             {
-                "name" : "openfaas/queue-worker",
-                "version" : "0.8.0"
+                "name": "openfaas/queue-worker",
+                "version": "0.11.0"
             },
             {
-                "name" : "openfaas/faas-idler",
-                "version" : "0.2.1"
+                "name": "openfaas/faas-idler",
+                "version": "0.3.0"
             },
             {
-                "name" : "prom/prometheus",
-                "version" : "v2.11.0"
+                "name": "prom/prometheus",
+                "version": "v2.11.0"
             },
             {
-                "name" : "prom/alertmanager",
-                "version" : "v0.18.0"
+                "name": "prom/alertmanager",
+                "version": "v0.18.0"
             },
             {
-                "name" : "nats-streaming",
-                "version" : "0.11.2"
+                "name": "nats-streaming",
+                "version": "0.17.0"
             }
         ],
         "faas-cli": {
             "version": "0.12.4"
         }
     },
-    "tinywww" :{
-        "version" : "latest",
-        "containers" : [
-            {
-                "name" : "embano1/tinywww",
-                "version" : "latest"
-            }
-        ]
+    "tinywww": {
+        "version": "latest",
+        "containers": [{
+            "name": "embano1/tinywww",
+            "version": "latest"
+        }]
     },
-    "vmware-event-router" : {
-        "version" : "v0.4.0",
-        "containers" : [
-            {
-                "name": "vmware/veba-event-router",
-                "version": "v0.4.0"
-            }
-        ]
+    "vmware-event-router": {
+        "version": "v0.4.0",
+        "containers": [{
+            "name": "vmware/veba-event-router",
+            "version": "v0.4.0"
+        }]
     }
 }


### PR DESCRIPTION
> Summary

This change leverages the `veba-bom.json` file which contains the build of materials (BOM) for all components of VEBA including the individual containers and their respective versions. 

This can be used for informational purposes but will also serve as a single source of truth for what versions are automatically downloaded as part of building VEBA. A copy of the BOM will also be pushed into the appliance and stored under `/root/config/veba-bom.json` a reference point.

> Commit Details:

* 8895230e9746538d62d7adaa5c47a8cb8d61ceb6 - Refactors VEBA components to reference `veba-bom.json`
* 88bd3f29ae4a396814dbcfd829f41af01865cd9e - Update K8s to `v1.18.3`, Contour to `v1.4.0` and OpenFaaS to `0.10.5`

> Resolves

Closes: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/157
Closes: https://github.com/vmware-samples/vcenter-event-broker-appliance/issues/158

> Testing

Deployed new version of VEBA and ensure that all services and components are running at the desired version:

**K8s Version:**
```
kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.3", GitCommit:"2e7996e3e2712684bc73f0dec0200d64eec7fe40", GitTreeState:"clean", BuildDate:"2020-05-20T12:49:29Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}

kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.3", GitCommit:"2e7996e3e2712684bc73f0dec0200d64eec7fe40", GitTreeState:"clean", BuildDate:"2020-05-20T12:52:00Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.3", GitCommit:"2e7996e3e2712684bc73f0dec0200d64eec7fe40", GitTreeState:"clean", BuildDate:"2020-05-20T12:43:34Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
```

**Container Versions:**
```
# docker images

REPOSITORY                           TAG                 IMAGE ID            CREATED             SIZE
k8s.gcr.io/kube-proxy                v1.18.3             3439b7546f29        4 days ago          117MB
k8s.gcr.io/kube-scheduler            v1.18.3             76216c34ed0c        4 days ago          95.3MB
k8s.gcr.io/kube-controller-manager   v1.18.3             da26705ccb4b        4 days ago          162MB
k8s.gcr.io/kube-apiserver            v1.18.3             7e28efa976bd        4 days ago          173MB
vmware/veba-event-router             v0.4.0              361028d6c0f4        13 days ago         120MB
openfaas/queue-worker                0.11.0              156f3ea15fa6        3 weeks ago         9.76MB
antrea/antrea-ubuntu                 v0.6.0              36cc5d6d96b8        3 weeks ago         319MB
projectcontour/contour               latest              d1cef92ab185        4 weeks ago         39.5MB
projectcontour/contour               v1.4.0              d1cef92ab185        4 weeks ago         39.5MB
openfaas/faas-netes                  0.10.3              9f1afd1e679c        4 weeks ago         71.6MB
openfaas/basic-auth-plugin           0.18.17             4d5c7c56e1f4        4 weeks ago         16.6MB
openfaas/gateway                     0.18.17             9496eadeb6e5        4 weeks ago         30MB
envoyproxy/envoy                     v1.14.1             d7edcd82b299        6 weeks ago         169MB
openfaas/faas-idler                  0.3.0               93f8e669f6cf        2 months ago        26.4MB
k8s.gcr.io/pause                     3.2                 80d28bedfe5d        3 months ago        683kB
nats-streaming                       0.17.0              411737a82b95        3 months ago        16MB
k8s.gcr.io/coredns                   1.6.7               67da37a9a360        3 months ago        43.8MB
k8s.gcr.io/etcd                      3.4.3-0             303ce5db0e90        7 months ago        288MB
embano1/tinywww                      latest              4b399f0d56fc        7 months ago        9.71MB
prom/prometheus                      v2.11.0             b97ed892eb23        10 months ago       126MB
prom/alertmanager                    v0.18.0             ce3c87f17369        10 months ago       51.9MB
```

Deployed sample Python vSphere Tagging function to ensure everything was operational. 

```
# faas-cli list --tls-no-verify

Function                      	Invocations    	Replicas
pytag-fn                      	1              	1
```