### PR TITLE
Allow use of "http://" prefix in HTTPS Proxy config

### DIFF
--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -37,11 +37,11 @@
       <Category>Proxy Settings (optional)</Category>
         <Property ovf:key="guestinfo.http_proxy" ovf:type="string" ovf:userConfigurable="true">
             <Label>HTTP Proxy</Label>
-            <Description>Enter HTTP Proxy Server followed by the port and without typing "http://" before. Example: "proxy.provider.com:3128"</Description>
+            <Description>Enter HTTP Proxy URL followed by the port. Example: "http://proxy.provider.com:3128"</Description>
         </Property>
         <Property ovf:key="guestinfo.https_proxy" ovf:type="string" ovf:userConfigurable="true">
             <Label>HTTPS Proxy</Label>
-            <Description>Enter HTTPS Proxy Server followed by the port and without typing "https://" before. Example: "proxy.provider.com:3128"</Description>
+            <Description>Enter HTTPS Proxy URL followed by the port. Example: "https://proxy.provider.com:3128"</Description>
         </Property>
         <Property ovf:key="guestinfo.proxy_username" ovf:type="string" ovf:userConfigurable="true">
             <Label>Proxy Username (optional)</Label>


### PR DESCRIPTION
Updated OVF properties to suit previous commit

Signed-off-by: David Bibby <17053612+dsbibby@users.noreply.github.com>

Changed logic to require "http(s)://" on proxy URLs rather than make it optional.

Signed-off-by: David Bibby <davidsbibby@gmail.com>

Cleaned up formatting

Signed-off-by: David Bibby <davidsbibby@gmail.com>

Fixed logic around error handling of malformed proxy URLs

Signed-off-by: David Bibby <davidsbibby@gmail.com>

Fixed proxy error messages not appearing on console output

Signed-off-by: David Bibby <davidsbibby@gmail.com>

Improved readability with better variable naming

Signed-off-by: David Bibby <davidsbibby@gmail.com>