### PR TITLE
Update Linter and Unit Test Action

### DIFF
--- a/.github/workflows/router-unit-tests.yml
+++ b/.github/workflows/router-unit-tests.yml
@@ -1,8 +1,13 @@
 name: VMware Event Router Unit Tests
 
-# triggered on PRs but only when changes inside vmware-event-router (sub)dir(s)
+# triggered on every push and PRs but only when changes inside
+# vmware-event-router (sub)dir(s)
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'vmware-event-router/**'
+  push:
     paths:
       - 'vmware-event-router/**'
 
@@ -18,6 +23,5 @@ jobs:
     steps:
       - name: checkout source
         uses: actions/checkout@master
-      - name: run unit tests
-        run: make test
-          
+      - name: run unit tests and verify image build (w/out push)
+        run: make build

--- a/vmware-event-router/Dockerfile
+++ b/vmware-event-router/Dockerfile
@@ -6,7 +6,7 @@ ARG COMMIT
 WORKDIR /build
 
 # install linter into ./bin/
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.23.7
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.27.0
 
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
Update Golang linter to latest version. Unit tests will now also verify
whether container image can be build.

Closes: #128 

Signed-off-by: Michael Gasch <mgasch@vmware.com>