### PR TITLE
Update Docker images used in VMware Event Router

### DIFF
--- a/vmware-event-router/Dockerfile
+++ b/vmware-event-router/Dockerfile
@@ -1,5 +1,5 @@
-# golang:1.13.7-stretch
-FROM golang@sha256:d16d1e0b4021e15dfc17dc58e794ad1e794155abf74c579a4c7b8a2c83ff8682 AS builder
+# golang:1.14.4-stretch amd64
+FROM golang@sha256:8b6b86e45c7847fea9cf401da52e41747cfb18bbfb4aebe924b4ef13a3366521 AS builder
 ARG VERSION
 ARG COMMIT
 
@@ -18,8 +18,8 @@ COPY internal internal
 RUN ./bin/golangci-lint run ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT}" -o vmware-event-router cmd/main.go
 
-# debian:stable-slim
-FROM debian@sha256:55f6837fd25a8e2ab94790bc73e762ffeb0d5d2e510177aef76101d2822d5937
+# debian:stable-slim amd64
+FROM debian@sha256:aa1db351593d2849034c0395bc604dd65aa80ae4471da4a37a0c38e30aed3ab8
 ARG VERSION
 ARG COMMIT
 LABEL maintainer="mgasch@vmware.com" \


### PR DESCRIPTION
Dockerfile build and deploy stage will use latest available Docker
images for Golang/Debian as of filing this commit.

Closes: #167 

Signed-off-by: Michael Gasch <mgasch@vmware.com>