### PR TITLE
Updated Fling URL from vcenter to vmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VMware Event Broker Appliance
 
 [![Photon OS 3.0](https://img.shields.io/badge/Photon%20OS-3.0-orange)](https://vmware.github.io/photon/)
-[![Published VMware Fling](https://img.shields.io/badge/VMware-Fling-green)](https://flings.vmware.com/vcenter-event-broker-appliance)
+[![Published VMware Fling](https://img.shields.io/badge/VMware-Fling-green)](https://flings.vmware.com/vmware-event-broker-appliance)
 ![Website](https://img.shields.io/website?label=vmweventbroker.io&url=https%3A%2F%2Fvmweventbroker.io%2F)
 [![Twitter Follow](https://img.shields.io/twitter/follow/lamw?style=social)](https://twitter.com/lamw)
 [![Twitter Follow](https://img.shields.io/twitter/follow/embano1?style=social)](https://twitter.com/embano1)
@@ -26,7 +26,7 @@ Visit our website [vmweventbroker.io](https://vmweventbroker.io/) and explore ou
 
 ## Overview
 
-The [VMware Event Broker Appliance](https://flings.vmware.com/vcenter-event-broker-appliance#summary) Fling enables customers to unlock the hidden potential of events in their SDDC to easily create [event-driven automation](https://octo.vmware.com/vsphere-power-event-driven-automation/) and take vCenter Server Events to the next level! Extending vSphere by easily triggering custom or prebuilt actions to deliver powerful integrations within your datacenter across public cloud has never been more easier before. A detailed list of use cases and possibilities with VMware Event Broker Appliance is available [here](https://vmweventbroker.io)
+The [VMware Event Broker Appliance](https://flings.vmware.com/vmware-event-broker-appliance#summary) Fling enables customers to unlock the hidden potential of events in their SDDC to easily create [event-driven automation](https://octo.vmware.com/vsphere-power-event-driven-automation/) and take vCenter Server Events to the next level! Extending vSphere by easily triggering custom or prebuilt actions to deliver powerful integrations within your datacenter across public cloud has never been more easier before. A detailed list of use cases and possibilities with VMware Event Broker Appliance is available [here](https://vmweventbroker.io)
 
 With this appliance, end-users, partners and independent software vendors only have to write minimal business logic without going through a steep learning curve understanding vSphere APIs. As such, we believe this solution not only offers a better user experience in solving existing problems for vSphere operators. More importantly, it will enable new integration use cases and workflows to grow the vSphere ecosystem and community, similar to what AWS has achieved with AWS Lambda.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,7 +46,7 @@ footer_social_links:
 
 github:
   zip_url: https://github.com/vmware-samples/vcenter-event-broker-appliance/archive/master.zip
-  fling_url: https://flings.vmware.com/vcenter-event-broker-appliance
+  fling_url: https://flings.vmware.com/vmware-event-broker-appliance
     
 collections:
   - functions

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@ hero:
   content: Use event-driven automation and take your vSphere Events to the next level! Easily trigger custom or pre-built actions to deliver powerful integrations within your datacenter but also across public cloud services. Integrations like Slack, Pager Duty, Service Now, etc. has never been easier before
   cta_link1:
     text: Download & Install
-    external_url: https://flings.vmware.com/vcenter-event-broker-appliance
+    external_url: https://flings.vmware.com/vmware-event-broker-appliance
   cta_link2:
     text: Deploy Functions
     url: /examples

--- a/docs/kb/install-eventbridge.md
+++ b/docs/kb/install-eventbridge.md
@@ -25,7 +25,7 @@ Customers looking to seamlessly extend their vCenter through native AWS componen
 * Access credentials for AWS account
 * Details about the AWS EventBridge setup (Rules, Region etc) 
 
-### Step 1 - Download the VMware Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vcenter-event-broker-appliance){:target="_blank"}.
+### Step 1 - Download the VMware Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vmware-event-broker-appliance){:target="_blank"}.
 
 ### Step 2 - Deploy the VMware Event Broker Appliance OVA to your vCenter Server using the vSphere HTML5 Client. As part of the deployment you will be prompted to provide the following input:
 

--- a/docs/kb/install-openfaas.md
+++ b/docs/kb/install-openfaas.md
@@ -23,7 +23,7 @@ Customers looking to seamlessly extend their vCenter by either deploying our pre
 * vCenter Server 6.x or greater
 * Account to login to vCenter Server (readOnly is sufficient)
 
-### Step 1 - Download the VMware Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vcenter-event-broker-appliance){:target="_blank"}.
+### Step 1 - Download the VMware Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vmware-event-broker-appliance){:target="_blank"}.
 
 ### Step 2 - Deploy the VMware Event Broker Appliance OVA to your vCenter Server using the vSphere HTML5 Client. As part of the deployment you will be prompted to provide the following input:
 

--- a/docs/kb/intro-about.md
+++ b/docs/kb/intro-about.md
@@ -14,7 +14,7 @@ cta:
 
 # VMware Event Broker Appliance
 
-The [VMware Event Broker Appliance](https://flings.vmware.com/vcenter-event-broker-appliance#summary){:target="_blank"} Fling enables customers to unlock the hidden potential of events in the SDDC to easily create [event-driven automation](https://octo.vmware.com/vsphere-power-event-driven-automation/){:target="_blank"} and take vCenter Server Events to the next level! Extending vSphere by easily triggering custom or prebuilt actions to deliver powerful integrations within your datacenter across public cloud has never been more easier before. 
+The [VMware Event Broker Appliance](https://flings.vmware.com/vmware-event-broker-appliance#summary){:target="_blank"} Fling enables customers to unlock the hidden potential of events in the SDDC to easily create [event-driven automation](https://octo.vmware.com/vsphere-power-event-driven-automation/){:target="_blank"} and take vCenter Server Events to the next level! Extending vSphere by easily triggering custom or prebuilt actions to deliver powerful integrations within your datacenter across public cloud has never been more easier before. 
 
 VMware Event Broker Appliance is provided as a virtual appliance that can be deployed to any vSphere-based infrastructure, including an on-premises and/or any public cloud environment running on vSphere such as VMware Cloud on AWS or VMware Cloud on DellEMC.
 

--- a/docs/zcleanup/getting-started.md
+++ b/docs/zcleanup/getting-started.md
@@ -8,7 +8,7 @@
 * vCenter Server 6.x or greater
 * Account to login to vCenter Server (readOnly is sufficient)
 
-**Step 1** - Download the vCenter Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vcenter-event-broker-appliance).
+**Step 1** - Download the vCenter Event Broker Appliance (OVA) from the [VMware Fling site](https://flings.vmware.com/vmware-event-broker-appliance).
 
 **Step 2** - Deploy the vCenter Event Broker Appliance OVA to your vCenter Server using the vSphere HTML5 Client. As part of the deployment you will be prompted to provide the following input:
 


### PR DESCRIPTION
Link change to reference the new flings URL  vmware-event-broker-appliance instead of vcenter-event-broker-appliance. The redirect works currently but we might as well reference the correct link.

Tested by clicking the link on local webserver.

Signed-off-by: Patrick Kremer <pkremer@vmware.com>