### PR TITLE
Add function HA Restarted VMs Email Notification

### DIFF
--- a/docs/site/examples.md
+++ b/docs/site/examples.md
@@ -103,6 +103,15 @@ examples:
     links: 
     - language: python
       url: "/tree/master/examples/python/invoke-rest-api"
+
+  - title: HA Restarted VMs Notification
+    usecases: 
+    - item: notification
+    id: ha-restarted-vms
+    description: Send an email listing all of the VMs which were restarted due to a host failure in an HA enabled cluster.
+    links: 
+    - language: powercli
+      url: "/tree/master/examples/powercli/ha-restarted-vms"
 ---
 
 A complete and updated list of ready to use functions curated by the VMware Event Broker community is listed below. 

--- a/examples/powercli/ha-restarted-vms/README.md
+++ b/examples/powercli/ha-restarted-vms/README.md
@@ -1,0 +1,100 @@
+# HA Restarted VMs Email Notification
+
+## Description
+
+This function demonstrates using PowerShell and PowerCLI to send an HTML formatted email notification containing a list of all VMs which were restarted due to a host failure in an HA enabled cluster.  The body of the email contains the VM names, time the VMs were restarted, and the contents of the VM notes/description field.
+
+## Consume Function Instruction
+
+Step 1 - Clone repo
+
+```
+git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
+cd vcenter-event-broker-appliance/examples/powercli/ha-restarted-vms
+git checkout master
+```
+
+Step 2 - Update `stack.yml` and `vcconfig-ha-restarted-vms.json` with your environment information
+
+<B>Note:</B> Be sure to configure all of the appropriate SMTP fields such as the SMTP_SERVER and SMTP_PORT for your particular SMTP server.  If authentication is not needed for your SMTP server, you can leave SMTP_USERNAME and SMTP_PASSWORD blank.
+
+Step 3 - Login to the OpenFaaS gateway on vCenter Event Broker Appliance
+
+```
+VEBA_GATEWAY=https://veba.abc.com
+export OPENFAAS_URL=${VEBA_GATEWAY}
+
+faas-cli login --username admin --password-stdin --tls-no-verify
+```
+
+Step 4 - Create function secret (only required once)
+
+```
+faas-cli secret create vcconfig-ha-restarted-vms --from-file=vcconfig-ha-restarted-vms.json --tls-no-verify
+```
+
+Step 5 - Deploy function to vCenter Event Broker Appliance
+
+```
+faas-cli deploy -f stack.yml --tls-no-verify
+```
+
+## Build Function Instruction
+
+Step 1 - Clone repo
+
+```
+git clone https://github.com/vmware-samples/vcenter-event-broker-appliance
+cd vcenter-event-broker-appliance/examples/powercli/ha-restarted-vms
+git checkout master
+```
+
+Step 2 - Verify the template/powercli directory and its contents exists - Needed for build
+
+```
+ls -R template/
+
+template/:
+powercli
+
+template/powercli:
+Dockerfile  function  template.yml
+
+template/powercli/function:
+script.ps1
+```
+
+Step 3 - Update `stack.yml` and `vcconfig-ha-restarted-vms.json` with your environment information. Please ensure you replace the name of the container image with your own account.
+
+Step 4 - Build the function container
+
+```
+faas-cli build -f stack.yml
+```
+
+Step 5 - Push the function container to Docker Registry (default but can be changed to internal registry)
+
+```
+faas-cli push -f stack.yml
+```
+
+Step 6 - Login to the OpenFaaS gateway on vCenter Event Broker Appliance
+
+```
+VEBA_GATEWAY=https://veba.abc.com
+export OPENFAAS_URL=${VEBA_GATEWAY}
+
+faas-cli login --username admin --password-stdin --tls-no-verify
+```
+
+Step 7 - Create function secret (only required once)
+
+```
+faas-cli secret create vcconfig-ha-restarted-vms --from-file=vcconfig-ha-restarted-vms.json --tls-no-verify
+```
+
+Step 8 - Deploy function to vCenter Event Broker Appliance
+
+```
+faas-cli deploy -f stack.yml --tls-no-verify
+```

--- a/examples/powercli/ha-restarted-vms/handler/script.ps1
+++ b/examples/powercli/ha-restarted-vms/handler/script.ps1
@@ -1,0 +1,77 @@
+# Process function Secrets passed in
+$VC_CONFIG_FILE = "/var/openfaas/secrets/vcconfig-ha-restarted-vms"
+$VC_CONFIG = (Get-Content -Raw -Path $VC_CONFIG_FILE | ConvertFrom-Json)
+if($env:function_debug -eq "true") {
+    Write-host "DEBUG: `"$VC_CONFIG`""
+}
+
+# Process payload sent from vCenter Server Event
+$json = $args | ConvertFrom-Json
+if($env:function_debug -eq "true") {
+    Write-Host "DEBUG: `"$json`""
+}
+
+Set-PowerCLIConfiguration -InvalidCertificateAction Ignore  -DisplayDeprecationWarnings $false -ParticipateInCeip $false -Confirm:$false | Out-Null
+
+# Connect to vCenter Server
+Write-Host "Connecting to vCenter Server ..."
+Connect-VIServer -Server $($VC_CONFIG.VC) -User $($VC_CONFIG.VC_USERNAME) -Password $($VC_CONFIG.VC_PASSWORD)
+
+# Main processing of gathering specific events
+$report = @()
+$eventnumber = 1000
+# get vCenter EventManager
+$si = get-view ServiceInstance
+$em = get-view $si.Content.EventManager
+
+# Create Event Filter Spec
+$EventFilterSpec = New-Object VMware.Vim.EventFilterSpec
+# Get specific Events based on EventTypeIDs for EventFilterSpec
+$tgtEvtTypeIDs = "com.vmware.vc.ha.VmRestartedByHAEvent", "com.vmware.vc.HA.DasHostFailedEvent"
+$EventFilterSpec.EventTypeId = $tgtEvtTypeIDs
+# Time range to look for specific IDs (current day specified) for EventFilterSpec
+$EventFilterSpecByTime = New-Object VMware.Vim.EventFilterSpecByTime
+$EventFilterSpecByTime.BeginTime = [datetime]::Today
+$EventFilterSpecByTime.EndTime = ([datetime]::Today).AddDays(+1)
+$EventFilterSpec.Time = $EventFilterSpecByTime
+# Create an Event Collector and loop through events storing them into an array
+$eCollector = Get-View ($em.CreateCollectorForEvents($EventFilterSpec))
+$events = $eCollector.ReadNextEvents($eventnumber)
+
+While ($events) {
+    $events | %{
+        $report += $_
+    }
+    $events = $eCollector.ReadNextEvents($eventnumber)
+}
+
+$eCollector.DestroyCollector()
+
+# Retrieve Host name of ESXi host which crashed - used for email report
+if ($report | Where-Object{$_.EventTypeId -eq "com.vmware.vc.HA.DasHostFailedEvent"}) {
+    # Displays just hostname - strips FQDN
+    $vmHost = ($report | Where-Object {$_.EventTypeId -eq "com.vmware.vc.HA.DasHostFailedEvent"} | Select-Object ObjectName -ExpandProperty ObjectName -First 1).split(".")[0]
+    # Displays host FQDN
+    #$vmHost = $report | Where-Object {$_.EventTypeId -eq "com.vmware.vc.HA.DasHostFailedEvent"} | Select-Object ObjectName -ExpandProperty ObjectName -First 1
+}
+
+# Set up fields for email body and send email - only sending VMname, time VM restarted on another host, and VM description
+$output = $report | Where-Object {$_.ObjectType -eq "VirtualMachine" } | Select-Object ObjectName, @{N = "Date"; E = { $_.CreatedTime } }, @{N = "Description"; E = { (" - " + (Get-view -id $_.vm.vm).config.annotation | Out-String) } } | Sort-Object ObjectName
+$msgBody = $output | ConvertTo-Html | Out-String
+$subject = "** $vmHost Failure - VMs Restarted **"
+
+# If defined in the config file, send via authenticated SMTP, otherwise use standard SMTP (credit @kremerpatrick)
+if ($VC_CONFIG.SMTP_PASSWORD.length -gt 0 -and $VC_CONFIG.SMTP_USERNAME.length -gt 0)
+{
+    $password = ConvertTo-SecureString "$($VC_CONFIG.SMTP_PASSWORD)" -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential($($VC_CONFIG.SMTP_USERNAME), $password)
+    Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO)  -Subject $subject -Body $msgBody -BodyAsHtml -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -UseSsl -Credential $credential #-Encoding UTF32
+}
+else
+{
+    Send-MailMessage -From $($VC_CONFIG.EMAIL_FROM) -to $($VC_CONFIG.EMAIL_TO) -Subject $subject -Body $msgBody -BodyAsHtml -SmtpServer $($VC_CONFIG.SMTP_SERVER) -port $($VC_CONFIG.SMTP_PORT) -Encoding UTF32
+}
+
+# Disconnect from vCenter
+Write-Host "Disconnecting from vCenter Server ..."
+Disconnect-VIServer * -Confirm:$false

--- a/examples/powercli/ha-restarted-vms/stack.yml
+++ b/examples/powercli/ha-restarted-vms/stack.yml
@@ -1,0 +1,17 @@
+version: 1.0
+provider:
+  name: openfaas
+  gateway: https://veba.abc.com
+functions:
+  powercli-ha-restarted-vms:
+    lang: powercli
+    handler: ./handler
+    image: vmware/veba-powercli-ha-restarted-vms:latest
+    environment:
+      write_debug: true
+      read_debug: true
+      function_debug: false
+    secrets:
+      - vcconfig-ha-restarted-vms
+    annotations:
+      topic: com.vmware.vc.HA.ClusterFailoverActionCompletedEvent

--- a/examples/powercli/ha-restarted-vms/template/powercli/Dockerfile
+++ b/examples/powercli/ha-restarted-vms/template/powercli/Dockerfile
@@ -1,0 +1,26 @@
+FROM vmware/powerclicore:latest
+
+RUN mkdir -p /home/app
+USER root
+RUN echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && cp /usr/bin/fwatchdog /root
+
+
+
+WORKDIR /root
+
+USER root
+
+# Populate example here - i.e. "cat", "sha512sum" or "node index.js"
+SHELL [ "pwsh", "-command" ]
+ENV fprocess="xargs pwsh ./function/script.ps1"
+COPY function function
+# Set to true to see request in function logs
+ENV write_debug="true"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+CMD [ "fwatchdog" ]

--- a/examples/powercli/ha-restarted-vms/template/powercli/function/script.ps1
+++ b/examples/powercli/ha-restarted-vms/template/powercli/function/script.ps1
@@ -1,0 +1,2 @@
+Set-PowerCLIConfiguration -InvalidCertificateAction Ignore  -DisplayDeprecationWarnings $false -ParticipateInCeip $false -Confirm:$false
+write-host "write your powercli code here"

--- a/examples/powercli/ha-restarted-vms/template/powercli/template.yml
+++ b/examples/powercli/ha-restarted-vms/template/powercli/template.yml
@@ -1,0 +1,3 @@
+language: powercli
+fprocess: xargs pwsh ./function/script.ps1
+

--- a/examples/powercli/ha-restarted-vms/vcconfig-ha-restarted-vms.json
+++ b/examples/powercli/ha-restarted-vms/vcconfig-ha-restarted-vms.json
@@ -1,0 +1,11 @@
+{
+    "VC" : "",
+    "VC_USERNAME" : "",
+    "VC_PASSWORD" : "",
+    "SMTP_SERVER" : "smtp.mailserver.com",
+    "SMTP_PORT" : "25",
+    "SMTP_USERNAME" : "",
+    "SMTP_PASSWORD" : "",
+    "EMAIL_TO": ["email_recipients@abc.com"],
+    "EMAIL_FROM" : "email_sender@abc.com"
+}


### PR DESCRIPTION
This example demonstrates using VEBA and PowerShell/PowerCLI to send an email notification listing all VMs which were restarted due to a host failure in an HA enabled cluster.

Testing environment:  vCenter 6.7 and VEBA v0.4 & 0.4.1 (w/OpenFaas)
Tested by "forcefully" restarting/resetting physical server causing an HA fail over event.


Signed-off-by:  rkt6865 robert_terra@brown.edu