### PR TITLE
Integrate new YAML format for VMware Event Router

### DIFF
--- a/files/setup-05-event-processor.sh
+++ b/files/setup-05-event-processor.sh
@@ -14,7 +14,7 @@ kubectl --kubeconfig /root/.kube/config -n vmware create secret generic basic-au
         --from-literal=basic-auth-password="${ROOT_PASSWORD}"
 
 # Setup Event Processor Configuration File
-EVENT_ROUTER_CONFIG=/root/config/event-router-config.json
+EVENT_ROUTER_CONFIG=/root/config/event-router-config.yaml
 
 # Slicing of escaped variables needed to properly handle the double quotation issue with constructing vCenter Server URL
 ESCAPED_VCENTER_SERVER=$(echo -n ${VCENTER_SERVER} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
@@ -31,50 +31,41 @@ if [ "${EVENT_PROCESSOR_TYPE}" == "AWS EventBridge" ]; then
 	ESCAPED_AWS_EVENTBRIDGE_RULE_ARN=$(echo -n ${AWS_EVENTBRIDGE_RULE_ARN} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
 
     cat > ${EVENT_ROUTER_CONFIG} << __AWS_EVENTBRIDGE_PROCESSOR__
-[{
-		"type": "stream",
-		"provider": "vmware_vcenter",
-		"address": "https://${ESCAPED_VCENTER_SERVER}/sdk",
-		"auth": {
-			"method": "user_password",
-			"secret": {
-				"username": "${ESCAPED_VCENTER_USERNAME}",
-				"password": "${ESCAPED_VCENTER_PASSWORD}"
-			}
-		},
-		"options": {
-			"insecure": "${VCENTER_DISABLE_TLS}"
-		}
-	},
-	{
-		"type": "processor",
-		"provider": "aws_event_bridge",
-		"auth": {
-			"method": "access_key",
-			"secret": {
-				"aws_access_key_id": "${ESCAPED_AWS_EVENTBRIDGE_ACCESS_KEY}",
-				"aws_secret_access_key": "${ESCAPED_AWS_EVENTBRIDGE_ACCESS_SECRET}"
-			}
-		},
-		"options": {
-			"aws_region": "${AWS_EVENTBRIDGE_REGION}",
-			"aws_eventbridge_event_bus": "${ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS}",
-			"aws_eventbridge_rule_arn": "${ESCAPED_AWS_EVENTBRIDGE_RULE_ARN}"
-		}
-	},
-	{
-		"type": "metrics",
-		"provider": "internal",
-		"address": "0.0.0.0:8080",
-		"auth": {
-			"method": "basic_auth",
-			"secret": {
-				"username": "admin",
-				"password": "${ESCAPED_ROOT_PASSWORD}"
-			}
-		}
-	}
-]
+apiVersion: event-router.vmware.com/v1alpha1
+eventProcessor:
+  awsEventBridge:
+    auth:
+      awsAccessKeyAuth:
+        accessKey: ${ESCAPED_AWS_EVENTBRIDGE_ACCESS_KEY}
+        secretKey: ${ESCAPED_AWS_EVENTBRIDGE_ACCESS_SECRET}
+      type: aws_access_key
+    eventBus: ${ESCAPED_AWS_EVENTBRIDGE_EVENT_BUS}
+    region: ${AWS_EVENTBRIDGE_REGION}
+    ruleARN: ${ESCAPED_AWS_EVENTBRIDGE_RULE_ARN}
+  name: veba-aws
+  type: awsEventBridge
+eventProvider:
+  name: veba-vc-01
+  type: vcenter
+  vcenter:
+    address: https://${ESCAPED_VCENTER_SERVER}/sdk
+    auth:
+      basicAuth:
+        password: ${ESCAPED_VCENTER_PASSWORD}
+        username: ${ESCAPED_VCENTER_USERNAME}
+      type: basic_auth
+    insecureSSL: ${VCENTER_DISABLE_TLS}
+    checkpoint: false
+kind: RouterConfig
+metadata:
+  labels:
+    key: value
+  name: router-config-aws
+metricsProvider:
+  default:
+    bindAddress: 0.0.0.0:8082
+  name: veba-metrics
+  type: default
 __AWS_EVENTBRIDGE_PROCESSOR__
 echo "Processor: EventBridge" >> /etc/veba-release
 else
@@ -92,49 +83,40 @@ else
 	ESCAPED_OPENFAAS_PASSWORD=$(echo -n ${OPENFAAS_PASSWORD} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)[1:-1]')
 
     cat > ${EVENT_ROUTER_CONFIG} << __OPENFAAS_PROCESSOR__
-[{
-		"type": "stream",
-		"provider": "vmware_vcenter",
-		"address": "https://${ESCAPED_VCENTER_SERVER}/sdk",
-		"auth": {
-			"method": "user_password",
-			"secret": {
-				"username": "${ESCAPED_VCENTER_USERNAME}",
-				"password": "${ESCAPED_VCENTER_PASSWORD}"
-			}
-		},
-		"options": {
-			"insecure": "${VCENTER_DISABLE_TLS}"
-		}
-	},
-	{
-		"type": "processor",
-		"provider": "openfaas",
-		"address": "http://gateway.openfaas:8080",
-		"auth": {
-			"method": "basic_auth",
-			"secret": {
-				"username": "admin",
-				"password": "${ESCAPED_OPENFAAS_PASSWORD}"
-			}
-		},
-		"options": {
-			"async": "false"
-		}
-	},
-	{
-		"type": "metrics",
-		"provider": "internal",
-		"address": "0.0.0.0:8080",
-		"auth": {
-			"method": "basic_auth",
-			"secret": {
-				"username": "admin",
-				"password": "${ESCAPED_ROOT_PASSWORD}"
-			}
-		}
-	}
-]
+apiVersion: event-router.vmware.com/v1alpha1
+eventProcessor:
+  name: veba-openfaas
+  openfaas:
+    address: http://gateway.openfaas:8080
+    async: false
+    auth:
+      basicAuth:
+        password: ${ESCAPED_OPENFAAS_PASSWORD}
+        username: admin
+      type: basic_auth
+  type: openfaas
+eventProvider:
+  name: veba-vc-01
+  type: vcenter
+  vcenter:
+    address: https://${ESCAPED_VCENTER_SERVER}/sdk
+    auth:
+      basicAuth:
+        password: ${ESCAPED_VCENTER_PASSWORD}
+        username: ${ESCAPED_VCENTER_USERNAME}
+      type: basic_auth
+    insecureSSL: ${VCENTER_DISABLE_TLS}
+    checkpoint: false
+kind: RouterConfig
+metadata:
+  labels:
+    key: value
+  name: router-config-openfaas
+metricsProvider:
+  default:
+    bindAddress: 0.0.0.0:8082
+  name: veba-metrics
+  type: default
 __OPENFAAS_PROCESSOR__
 echo "Processor: OpenFaaS" >> /etc/veba-release
 fi

--- a/files/setup-06-event-router.sh
+++ b/files/setup-06-event-router.sh
@@ -34,7 +34,7 @@ spec:
       containers:
       - image: ${EVENT_ROUTER_IMAGE}:${EVENT_ROUTER_VERSION}
         imagePullPolicy: IfNotPresent
-        args: ["-config", "/etc/vmware-event-router/event-router-config.json", "-verbose"]
+        args: ["-config", "/etc/vmware-event-router/event-router-config.yaml"]
         name: vmware-event-router
         resources:
           requests:


### PR DESCRIPTION
## Summary

This change incorporates the new YAML format that the VMware Event Router accepts, previously this was JSON format. The default port for Event Router stats of 8080 has also changed to 8082 (internal) to prevent collision for local development purposes. 

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [x] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [x] Please include any relevant screenshots and/or output as part of your testing
- [x] Please include any documentation updates that is applicable for your changes

## Change Type

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* N/A

## Testing Verification

* Successfully deploy VEBA appliance using pre-release version (69c6d93) of VMware Event Router that uses YAML and ensures all pods are up and running and that Event Router is successfully started and processing vCenter Events. 

```
root@veba [ ~ ]# kubectl -n vmware logs vmware-event-router-6f764588cd-xcl9p | head -20

 _    ____  ___                            ______                 __     ____              __
| |  / /  |/  /      ______ _________     / ____/   _____  ____  / /_   / __ \____  __  __/ /____  _____
| | / / /|_/ / | /| / / __  / ___/ _ \   / __/ | | / / _ \/ __ \/ __/  / /_/ / __ \/ / / / __/ _ \/ ___/
| |/ / /  / /| |/ |/ / /_/ / /  /  __/  / /___ | |/ /  __/ / / / /_   / _, _/ /_/ / /_/ / /_/  __/ /
|___/_/  /_/ |__/|__/\__,_/_/   \___/  /_____/ |___/\___/_/ /_/\__/  /_/ |_|\____/\__,_/\__/\___/_/

[VMware Event Router] 2020/10/08 19:18:11 connecting to vCenter "https://192.168.30.200/sdk"
[VMware Event Router] 2020/10/08 19:18:11 connected to OpenFaaS gateway "http://gateway.openfaas:8080" (async mode: false)
[Metrics Server] 2020/10/08 19:18:11 no credentials found, disabling authentication for metrics server
[VMware Event Router] 2020/10/08 19:18:11 exposing metrics server on 0.0.0.0:8082
[Metrics Server] 2020/10/08 19:18:11 starting metrics server and listening on "http://0.0.0.0:8082/stats"
[vCenter] 2020/10/08 19:18:11 checkpointing disabled, setting begin of event stream to: 2020-10-08 19:18:12.126765 +0000 UTC
[OpenFaaS] 2020/10/08 19:18:30 invoking function(s) for event 34f93a9c-c717-4887-9222-5d3776c83465 on topic: com.vmware.vim.eam.agency.statusChanged
```

## Additional Information

* N/A
