### PR TITLE
Add event UUID to checkpoint

### DIFF
--- a/vmware-event-router/internal/events/events.go
+++ b/vmware-event-router/internal/events/events.go
@@ -31,7 +31,7 @@ type VCenterEventInfo struct {
 // the given BaseEvent, e.g. VmPoweredOnEvent (event) or
 // com.vmware.applmgmt.backup.job.failed.event (extendedevent)
 func GetDetails(event types.BaseEvent) VCenterEventInfo {
-	eventInfo := VCenterEventInfo{}
+	var eventInfo VCenterEventInfo
 
 	switch e := event.(type) {
 	case *types.EventEx:

--- a/vmware-event-router/internal/provider/vcenter/checkpoint_test.go
+++ b/vmware-event-router/internal/provider/vcenter/checkpoint_test.go
@@ -23,11 +23,13 @@ const (
 
 var (
 	now              = time.Now().UTC()
+	lastEventUUID    = "e5b89c60-d292-44cb-b5f0-7fef6d0e5fb4"
 	lastEventKey     = int32(1234)
 	lastEventType    = "VmPoweredOffEvent"
 	lastEventKeyTime = now.Add(time.Minute * -30) // 30min in past
 	validCheckpoint  = checkpoint{
 		VCenter:               vcHost,
+		LastEventUUID:         lastEventUUID,
 		LastEventKey:          lastEventKey,
 		LastEventType:         lastEventType,
 		LastEventKeyTimestamp: lastEventKeyTime,
@@ -101,7 +103,7 @@ func Test_checkpoint(t *testing.T) {
 	type args struct {
 		ctx       context.Context
 		vcHost    string
-		lastEvent types.BaseEvent
+		lastEvent lastEvent
 	}
 	tests := []struct {
 		name     string
@@ -116,12 +118,16 @@ func Test_checkpoint(t *testing.T) {
 			args: args{
 				ctx:    ctx,
 				vcHost: vcHost,
-				lastEvent: &types.VmPoweredOffEvent{
-					VmEvent: types.VmEvent{
-						Event: types.Event{
-							Key:         lastEventKey,
-							CreatedTime: lastEventKeyTime},
+				lastEvent: lastEvent{
+					baseEvent: &types.VmPoweredOffEvent{
+						VmEvent: types.VmEvent{
+							Event: types.Event{
+								Key:         lastEventKey,
+								CreatedTime: lastEventKeyTime},
+						},
 					},
+					uuid: lastEventUUID,
+					key:  lastEventKey,
 				},
 			},
 			wantFile: string(jsonValid),
@@ -134,7 +140,7 @@ func Test_checkpoint(t *testing.T) {
 			args: args{
 				ctx:       ctx,
 				vcHost:    vcHost,
-				lastEvent: nil,
+				lastEvent: lastEvent{baseEvent: nil},
 			},
 			wantFile: "",
 			wantCP:   nil,


### PR DESCRIPTION
This change adds the last event UUID processed to the checkpoint to ease
troubleshooting and visibility into checkpointing.

The updated file format is:

```json
{
  "vCenter": "10.0.0.1",
  "lastEventUUID": "f8d71cb0-fd66-4e3b-aae1-b62d4576bf40",
  "lastEventKey": 26071,
  "lastEventType": "UserLogoutSessionEvent",
  "lastEventKeyTimestamp": "2020-10-13T08:05:36.792Z",
  "createdTimestamp": "2020-10-13T08:05:55.534638Z"
}
```

Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Summary

Please describe your changes and what you plan to introduce as part of this pull request submission. If it fixes a bug or resolves a feature request, be sure to link to the issue numbers following the template below.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [x] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

* Closes #228

## Testing Verification

Unit and integration tests pass.