### PR TITLE
Include all files in gofmt

### DIFF
--- a/vmware-event-router/Makefile
+++ b/vmware-event-router/Makefile
@@ -48,7 +48,7 @@ build: unit-test tidy
 
 gofmt:
 	$(info Make: Checking code is gofmted.)
-	@test -z "$(shell gofmt -s -l -d -e ./cmd | tee /dev/stderr)"
+	@test -z "$(shell gofmt -s -l -d -e . | tee /dev/stderr)"
 
 lint:
 	$(info Make: Running linter.)


### PR DESCRIPTION
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Summary

Fix for Makefile only running gofmt against `cmd`.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

n/a

## Testing Verification

Unit/integration tests pass.

## Additional Information

n/a