### PR TITLE
Bump OpenFaaS SDK version

### DIFF
--- a/vmware-event-router/go.mod
+++ b/vmware-event-router/go.mod
@@ -26,4 +26,4 @@ require (
 	knative.dev/pkg v0.0.0-20201109175709-2c9320ae0640
 )
 
-replace github.com/openfaas-incubator/connector-sdk => github.com/embano1/connector-sdk v0.0.0-20201021143238-8291e33b7d6d
+replace github.com/openfaas-incubator/connector-sdk => github.com/embano1/connector-sdk v0.0.0-20201209211641-e6a3409ab348

--- a/vmware-event-router/go.sum
+++ b/vmware-event-router/go.sum
@@ -152,8 +152,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/embano1/connector-sdk v0.0.0-20201021143238-8291e33b7d6d h1:CKyhpRBDirxWVXg0QkPNlM+6r9OF/q9UGF48J8KHyS8=
-github.com/embano1/connector-sdk v0.0.0-20201021143238-8291e33b7d6d/go.mod h1:xQK4clyPbZ1MfdIk3cU212TiS8VUwuX8RZvwtFBtacA=
+github.com/embano1/connector-sdk v0.0.0-20201209211641-e6a3409ab348 h1:504fYj6Sn07M27KkDkVz7kTu8SuM3pd76QfpKZLJZzU=
+github.com/embano1/connector-sdk v0.0.0-20201209211641-e6a3409ab348/go.mod h1:xQK4clyPbZ1MfdIk3cU212TiS8VUwuX8RZvwtFBtacA=
 github.com/embano1/waitgroup v0.0.0-20201120223302-1d5df9b49112 h1:kkUBqf7sMY9FDOWtJtG+NG71HmeyEamZE2ssGcALLXM=
 github.com/embano1/waitgroup v0.0.0-20201120223302-1d5df9b49112/go.mod h1:xIKMM6mvwOOlKMak0IkCruE/fHg6ONYIpiGVjbi+R5w=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
## Summary

Uses a recent version of the forked SDK to improve the error handling
when credentials are missing or wrong but basic auth in the OpenFaaS
gateway is enforced.

⚠️  
**Note:** This PR is explicitly against the release branch (`v0.5.0`) to not delay this enhancement due to several issues faced during release testing caused by this error message.

Instead of this rather useless error message due to wrong OF gateway credentials:

```bash
 _    ____  ___                            ______                 __     ____              __
| |  / /  |/  /      ______ _________     / ____/   _____  ____  / /_   / __ \____  __  __/ /____  _____
| | / / /|_/ / | /| / / __  / ___/ _ \   / __/ | | / / _ \/ __ \/ __/  / /_/ / __ \/ / / / __/ _ \/ ___/
| |/ / /  / /| |/ |/ / /_/ / /  /  __/  / /___ | |/ /  __/ / / / /_   / _, _/ /_/ / /_/ / /_/  __/ /
|___/_/  /_/ |__/|__/\__,_/_/   \___/  /_____/ |___/\___/_/ /_/\__/  /_/ |_|\____/\__,_/\__/\___/_/
2020-12-09T22:10:09.406+0100    INFO    [MAIN]  router/main.go:111      connecting to vCenter   {"address": "https://10.184.99.138/sdk"}
2020-12-09T22:10:09.406+0100    INFO    [MAIN]  router/main.go:133      connected to OpenFaaS gateway   {"address": "http://localhost:8080", "async": false}
2020-12-09T22:10:09.406+0100    WARN    [METRICS]       metrics/server.go:59    no credentials found, disabling authentication for metrics server
2020-12-09T22:10:09.407+0100    INFO    [METRICS]       metrics/server.go:131   starting metrics server {"address": "http://0.0.0.0:8082/stats"}
2020-12-09T22:10:09.439+0100    FATAL   [OPENFAAS]      types/controller.go:179 invalid character 'i' looking for beginning of value
github.com/openfaas-incubator/connector-sdk/types.(*controller).synchronizeLookups.func1
        /Users/mgasch/GO/pkg/mod/github.com/embano1/connector-sdk@v0.0.0-20201021143238-8291e33b7d6d/types/controller.go:179
github.com/openfaas-incubator/connector-sdk/types.(*controller).synchronizeLookups
        /Users/mgasch/GO/pkg/mod/github.com/embano1/connector-sdk@v0.0.0-20201021143238-8291e33b7d6d/types/controller.go:189
```

Return this one:

```bash
 _    ____  ___                            ______                 __     ____              __
| |  / /  |/  /      ______ _________     / ____/   _____  ____  / /_   / __ \____  __  __/ /____  _____
| | / / /|_/ / | /| / / __  / ___/ _ \   / __/ | | / / _ \/ __ \/ __/  / /_/ / __ \/ / / / __/ _ \/ ___/
| |/ / /  / /| |/ |/ / /_/ / /  /  __/  / /___ | |/ /  __/ / / / /_   / _, _/ /_/ / /_/ / /_/  __/ /
|___/_/  /_/ |__/|__/\__,_/_/   \___/  /_____/ |___/\___/_/ /_/\__/  /_/ |_|\____/\__,_/\__/\___/_/
2020-12-09T22:11:27.736+0100    INFO    [MAIN]  router/main.go:111      connecting to vCenter   {"address": "https://10.184.99.138/sdk"}
2020-12-09T22:11:27.736+0100    INFO    [MAIN]  router/main.go:133      connected to OpenFaaS gateway   {"address": "http://localhost:8080", "async": false}
2020-12-09T22:11:27.736+0100    WARN    [METRICS]       metrics/server.go:59    no credentials found, disabling authentication for metrics server
2020-12-09T22:11:27.736+0100    INFO    [METRICS]       metrics/server.go:131   starting metrics server {"address": "http://0.0.0.0:8082/stats"}
2020-12-09T22:11:27.752+0100    FATAL   [OPENFAAS]      types/controller.go:179 authentication failure against gateway: Unauthorized
github.com/openfaas-incubator/connector-sdk/types.(*controller).synchronizeLookups.func1
        /Users/mgasch/GO/pkg/mod/github.com/embano1/connector-sdk@v0.0.0-20201209210506-a07fa04b767e/types/controller.go:179
github.com/openfaas-incubator/connector-sdk/types.(*controller).synchronizeLookups
        /Users/mgasch/GO/pkg/mod/github.com/embano1/connector-sdk@v0.0.0-20201209210506-a07fa04b767e/types/controller.go:189
```

Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

* Closes #277 

## Testing Verification

Tested against an OpenFaaS environment using basic auth with multiple functions. If the credentials are wrong a meaningful error is returned (see above).

## Additional Information

n/a