### PR TITLE
Update to OpenFaaS 0.12.15

### DIFF
--- a/files/setup-05-event-processor.sh
+++ b/files/setup-05-event-processor.sh
@@ -121,7 +121,7 @@ else
         --from-literal=basic-auth-user=admin \
         --from-literal=basic-auth-password="${OPENFAAS_PASSWORD}"
 
-    kubectl --kubeconfig /root/.kube/config create -f /root/download/faas-netes/yaml
+    kubectl --kubeconfig /root/.kube/config apply -f /root/download/faas-netes/yaml
 
 	ESCAPED_OPENFAAS_PASSWORD=$(echo -n ${OPENFAAS_PASSWORD} | python -c 'import sys,json;data=sys.stdin.read(); print json.dumps(data)')
 

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -61,26 +61,22 @@
         ]
     },
     "openfaas": {
-        "gitRepoTag": "0.10.5",
+        "gitRepoTag": "0.12.15",
         "containers": [{
-                "name": "openfaas/faas-netes",
-                "version": "0.10.3"
+                "name": "ghcr.io/openfaas/faas-netes",
+                "version": "0.12.13"
             },
             {
                 "name": "openfaas/gateway",
-                "version": "0.18.17"
+                "version": "0.20.2"
             },
             {
                 "name": "openfaas/basic-auth-plugin",
-                "version": "0.18.17"
+                "version": "0.20.1"
             },
             {
                 "name": "openfaas/queue-worker",
-                "version": "0.11.0"
-            },
-            {
-                "name": "openfaas/faas-idler",
-                "version": "0.3.0"
+                "version": "0.11.2"
             },
             {
                 "name": "prom/prometheus",
@@ -96,7 +92,7 @@
             }
         ],
         "faas-cli": {
-            "version": "0.12.4"
+            "version": "0.13.0"
         }
     },
     "tinywww": {


### PR DESCRIPTION
Signed-off-by: William Lam <wlam@vmware.com>

## Summary

In addition to the faas-idler:0.3.0 version no longer being available on dockerhub, it looks like faas-idler component is no longer part of the latest release of OpenFaaS. With the current version of OpenFaaS that is being used, we are unable to build VEBA appliance. This change updates OpenFaaS to the latest release 0.12.15 (at the time of testing) along with the required container images that are reflected in the VEBA bom file.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* Closes #292 

## Testing Verification

Successfully built and deployed new VEBA appliance as well as verified successful function deployment

```
k get pods -A
NAMESPACE        NAME                                                  READY   STATUS      RESTARTS   AGE
kube-system      antrea-agent-fxjs9                                    2/2     Running     0          49s
kube-system      antrea-controller-647fc85df-fgmqg                     1/1     Running     0          49s
kube-system      coredns-66bff467f8-4h2z5                              1/1     Running     0          49s
kube-system      coredns-66bff467f8-rq9mw                              1/1     Running     0          49s
kube-system      etcd-veba.primp-industries.local                      1/1     Running     0          59s
kube-system      kube-apiserver-veba.primp-industries.local            1/1     Running     0          59s
kube-system      kube-controller-manager-veba.primp-industries.local   1/1     Running     0          59s
kube-system      kube-proxy-wdc84                                      1/1     Running     0          49s
kube-system      kube-scheduler-veba.primp-industries.local            1/1     Running     0          59s
openfaas         alertmanager-6685ddf897-s78mq                         1/1     Running     0          49s
openfaas         basic-auth-plugin-865d6c5db6-zqcxr                    1/1     Running     0          49s
openfaas         gateway-5788c689bc-slfqv                              2/2     Running     0          49s
openfaas         nats-5cd4dff7c8-48g8j                                 1/1     Running     0          49s
openfaas         prometheus-7f94489d7d-vx5jr                           1/1     Running     0          49s
openfaas         queue-worker-6459f6f5c9-xgqrw                         1/1     Running     0          49s
projectcontour   contour-98d599f9f-6mj9l                               1/1     Running     0          47s
projectcontour   contour-98d599f9f-pfd48                               1/1     Running     0          47s
projectcontour   contour-certgen-v1.9.0-4j46t                          0/1     Completed   0          48s
projectcontour   envoy-q2qcj                                           2/2     Running     0          39s
vmware           tinywww-6dcd668667-v9sqt                              1/1     Running     0          49s
vmware           vmware-event-router-6976868859-p27c8                  1/1     Running     2          49s
```

```
faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  693bc31f1dda07eed484bf9635a8b2e2f4a838d8
 version: 0.13.0

❯ export OPENFAAS_URL=https://veba.primp-industries.local
faas-cli login -p 'VMware1!' --tls-no-verify
WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin
Calling the OpenFaaS server to validate the credentials...
credentials saved for admin https://veba.primp-industries.local

❯ faas-cli deploy -f stack.yml --tls-no-verify
Deploying: veba-echo.

Deployed. 202 Accepted.
URL: https://veba.primp-industries.local/function/veba-echo.openfaas-fn

❯ faas-cli logs veba-echo --tls-no-verify
2021-02-06T17:51:47Z Forking - python [index.py]
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Started logging stderr from function.
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Started logging stdout from function.
2021-02-06T17:51:47Z 2021/02/06 17:51:47 OperationalMode: http
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Timeouts: read: 10s, write: 10s hard: 10s.
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Listening on port: 8080
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Writing lock-file to: /tmp/.lock
2021-02-06T17:51:47Z 2021/02/06 17:51:47 Metrics listening on port: 8081
2021-02-06T17:52:12Z 2021/02/06 17:52:12 stdout: Serving on http://0.0.0.0:5000
2021-02-06T17:52:12Z 2021/02/06 17:52:12 stdout: b'{"data":{"Key":539241,"ChainId":539238,"CreatedTime":"2021-02-06T17:52:12.474999Z","UserName":"VSPHERE.LOCAL\\\\Administrator","Datacenter":{"Name":"Primp-Datacenter","Datacenter":{"Type":"Datacenter","Value":"datacenter-3"}},"ComputeResource":{"Name":"Supermicro-Cluster","ComputeResource":{"Type":"ClusterComputeResource","Value":"domain-c8"}},"Host":{"Name":"192.168.30.5","Host":{"Type":"HostSystem","Value":"host-11"}},"Vm":{"Name":"VMTX-VM","Vm":{"Type":"VirtualMachine","Value":"vm-2089"}},"Ds":null,"Net":null,"Dvs":null,"FullFormattedMessage":"DRS powered on VMTX-VM on 192.168.30.5 in Primp-Datacenter","ChangeTag":"","Template":false},"datacontenttype":"application/json","id":"d529dd0d-269c-4464-b36f-9e897b0e2ad4","source":"https://192.168.30.3/sdk","specversion":"1.0","subject":"DrsVmPoweredOnEvent","time":"2021-02-06T17:52:12.657586711Z","type":"com.vmware.event.router/event"}'
```