### PR TITLE
Update to K8s 1.20.2

### DIFF
--- a/veba-bom.json
+++ b/veba-bom.json
@@ -29,22 +29,22 @@
         ]
     },
     "kubernetes": {
-        "gitRepoTag": "v1.18.3",
+        "gitRepoTag": "v1.20.2",
         "containers": [{
                 "name": "k8s.gcr.io/kube-apiserver",
-                "version": "v1.18.3"
+                "version": "v1.20.2"
             },
             {
                 "name": "k8s.gcr.io/kube-controller-manager",
-                "version": "v1.18.3"
+                "version": "v1.20.2"
             },
             {
                 "name": "k8s.gcr.io/kube-scheduler",
-                "version": "v1.18.3"
+                "version": "v1.20.2"
             },
             {
                 "name": "k8s.gcr.io/kube-proxy",
-                "version": "v1.18.3"
+                "version": "v1.20.2"
             },
             {
                 "name": "k8s.gcr.io/pause",
@@ -52,11 +52,11 @@
             },
             {
                 "name": "k8s.gcr.io/etcd",
-                "version": "3.4.3-0"
+                "version": "3.4.13-0"
             },
             {
                 "name": "k8s.gcr.io/coredns",
-                "version": "1.6.7"
+                "version": "1.7.0"
             }
         ]
     },

--- a/vmware-event-router/hack/run_integration_tests.sh
+++ b/vmware-event-router/hack/run_integration_tests.sh
@@ -33,8 +33,7 @@ KINDBIN="kind"
 KIND_TIMEOUT=5m # exit if kind cluster creation does not complete within this time
 KIND_WAIT=2m    # wait for control plane to show ready
 KIND_CLUSTER="veba-integration"
-# using custom image built with kind since not all versions are pushed to kindtest
-KIND_IMAGE="embano1/node:${K8S_VERSION}"
+KIND_IMAGE="kindest/node:${K8S_VERSION}"
 #################################
 
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -76,9 +75,9 @@ fi
 # deploy faas-netes
 cecho "---> Deploying OpenFaaS (${OF_VERSION})" ${GREEN}
 git clone https://github.com/openfaas/faas-netes ${tmp_dir} && git -C ${tmp_dir} checkout ${OF_VERSION}
-kubectl create -f ${tmp_dir}/namespaces.yml
+kubectl apply -f ${tmp_dir}/namespaces.yml
 kubectl -n openfaas create secret generic basic-auth --from-literal=basic-auth-user=admin --from-literal=basic-auth-password="$OF_PASSWORD"
-kubectl create -f ${tmp_dir}/yaml
+kubectl apply -f ${tmp_dir}/yaml
 
 cecho "---> Waiting up to ${OF_TIMEOUT} for OpenFaaS gateway to become ready" ${GREEN}
 ${TIMEOUT_CMD} ${OF_TIMEOUT} /bin/bash -c 'while [[ $READY -lt 1 ]]; do READY=$(kubectl -n openfaas get deploy gateway -o json | '"${JQBIN}"' .status.readyReplicas); sleep 1; done'


### PR DESCRIPTION
Signed-off-by: William Lam <wlam@vmware.com>

## Summary

This change updates the version of K8s to the latest v1.20.2 release.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* Closes #293 

## Testing Verification

Successfully built and deployed VEBA appliance w/K8s 1.20.2

```
k get nodes -o wide
NAME                          STATUS   ROLES                  AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                 KERNEL-VERSION   CONTAINER-RUNTIME
veba.primp-industries.local   Ready    control-plane,master   127m   v1.20.2   192.168.30.9   <none>        VMware Photon OS/Linux   4.19.164-2.ph3   docker://19.3.10

k get pods -A
NAMESPACE        NAME                                                  READY   STATUS      RESTARTS   AGE
kube-system      antrea-agent-hz275                                    2/2     Running     1          127m
kube-system      antrea-controller-849fff8c5d-pc9qs                    1/1     Running     0          127m
kube-system      coredns-74ff55c5b-lx86x                               1/1     Running     0          127m
kube-system      coredns-74ff55c5b-r9pt4                               1/1     Running     0          127m
kube-system      etcd-veba.primp-industries.local                      1/1     Running     0          127m
kube-system      kube-apiserver-veba.primp-industries.local            1/1     Running     0          127m
kube-system      kube-controller-manager-veba.primp-industries.local   1/1     Running     0          127m
kube-system      kube-proxy-vsjll                                      1/1     Running     0          127m
kube-system      kube-scheduler-veba.primp-industries.local            1/1     Running     0          127m
openfaas         alertmanager-8697588d84-9j8dn                         1/1     Running     0          127m
openfaas         basic-auth-plugin-858495b9c6-8nmjr                    1/1     Running     0          127m
openfaas         gateway-5dd7fd4dc4-8fsmm                              2/2     Running     0          127m
openfaas         nats-cdc589ff7-sc9d8                                  1/1     Running     0          127m
openfaas         prometheus-7c6b97c87f-f8jgn                           1/1     Running     0          127m
openfaas         queue-worker-749c7964f4-k2wb6                         1/1     Running     0          127m
projectcontour   contour-77f4759d86-j4fr9                              1/1     Running     0          127m
projectcontour   contour-77f4759d86-qsg79                              1/1     Running     0          127m
projectcontour   contour-certgen-v1.9.0-m4k8h                          0/1     Completed   0          127m
projectcontour   envoy-7gsvf                                           2/2     Running     0          127m
vmware           tinywww-8464cc455b-q2k9z                              1/1     Running     0          127m
vmware           vmware-event-router-57755b7744-sck42                  1/1     Running     2          127m
```

