### PR TITLE
Configure log rotation for contrackd

### DIFF
--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -92,4 +92,16 @@ EOF
 
 systemctl enable getty@tty1.service
 
+echo '> Enable contrackd log rotation...'
+cat > /etc/logrotate.d/contrackd << EOF
+/var/log/conntrackd*.log {
+	missingok
+	size 5M
+	rotate 3
+        maxage 7
+	compress
+	copytruncate
+}
+EOF
+
 echo '> Done'


### PR DESCRIPTION
Signed-off-by: William Lam <wlam@vmware.com>

## Summary

This change introduces the enablement of log rotation for the contrackd logs. This has negatively impacted customers as there is currently no default log rotation for the contrackd stats logs which can/has filled up the filesystem on VEBA.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* Closes #294 

## Testing Verification

Successfully built and deployed VEBA appliance w/log rotation configured for the contrackd service

```
cat /etc/logrotate.d/contrackd
/var/log/conntrackd*.log {
	missingok
	size 5M
	rotate 3
        maxage 7
	compress
	copytruncate
}
```

Manually ran `/etc/cron.daily/logrotate` (since default cron is daily) to ensure the logrotate configuration was applied once filesize >=5MB

```
ls -lthr /var/log/conn*
-rw------- 1 root root 353K Feb  6 23:51 /var/log/conntrackd-stats.log-20210206.gz
-rw------- 1 root root 517K Feb  7 00:02 /var/log/conntrackd-stats.log
```

## Additional Information

* https://gitlab.alpinelinux.org/alpine/aports/-/issues/12333