### PR TITLE
Deploy local storage provisioner only for embedded Knative

### DIFF
--- a/files/setup-01-os.sh
+++ b/files/setup-01-os.sh
@@ -33,10 +33,12 @@ echo -e "\e[92mConfiguring IP Tables for Antrea ..." > /dev/console
 iptables -A INPUT -i gw0 -j ACCEPT
 iptables-save > /etc/systemd/scripts/ip4save
 
-echo -e "\e[92mConfiguring Local Storage Volume ..." > /dev/console
-parted ${LOCAL_STORAGE_DISK} --script mklabel gpt mkpart primary ext3 0% 100%
-mkfs -t ext3 ${LOCAL_STORAGE_DISK}1
-mkdir ${LOCAL_STOARGE_VOLUME_PATH}
-chmod 777 ${LOCAL_STOARGE_VOLUME_PATH}
-echo "${LOCAL_STORAGE_DISK}1       ${LOCAL_STOARGE_VOLUME_PATH}       ext3    defaults        0        0" >> /etc/fstab
-mount ${LOCAL_STOARGE_VOLUME_PATH}
+if [ "${KNATIVE_DEPLOYMENT_TYPE}" == "embedded" ]; then
+    echo -e "\e[92mConfiguring Local Storage Volume ..." > /dev/console
+    parted ${LOCAL_STORAGE_DISK} --script mklabel gpt mkpart primary ext3 0% 100%
+    mkfs -t ext3 ${LOCAL_STORAGE_DISK}1
+    mkdir ${LOCAL_STOARGE_VOLUME_PATH}
+    chmod 777 ${LOCAL_STOARGE_VOLUME_PATH}
+    echo "${LOCAL_STORAGE_DISK}1       ${LOCAL_STOARGE_VOLUME_PATH}       ext3    defaults        0        0" >> /etc/fstab
+    mount ${LOCAL_STOARGE_VOLUME_PATH}
+fi

--- a/files/setup-04-kubernetes.sh
+++ b/files/setup-04-kubernetes.sh
@@ -56,8 +56,10 @@ do
     sleep 10
 done
 
-echo -e "\e[92mDeploying Local Storage Provisioner ..." > /dev/console
-mkdir -p ${LOCAL_STOARGE_VOLUME_PATH}/local-path-provisioner
-chmod 777 ${LOCAL_STOARGE_VOLUME_PATH}/local-path-provisioner
-kubectl apply -f /root/download/local-path-storage.yaml
-kubectl patch sc local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+if [ "${KNATIVE_DEPLOYMENT_TYPE}" == "embedded" ]; then
+  echo -e "\e[92mDeploying Local Storage Provisioner ..." > /dev/console
+  mkdir -p ${LOCAL_STOARGE_VOLUME_PATH}/local-path-provisioner
+  chmod 777 ${LOCAL_STOARGE_VOLUME_PATH}/local-path-provisioner
+  kubectl apply -f /root/download/local-path-storage.yaml
+  kubectl patch sc local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+fi


### PR DESCRIPTION
Signed-off-by: William Lam <wlam@vmware.com>

## Summary

This change introduces a check that only setups the local storage provisioner configuration when VEBA is deployed using the embedded Knative deployment model. For both OpenFaaS and EventBridge, this configuration is not required and should not be setup.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* Closes #304 

## Testing Verification

Verified `/data/local-path-provisioner` is not created on filesystem nor local-path-provisioner containers are deployed