### PR TITLE
Fix /etc/resolv.conf from reverting back to local DNS stub address

### DIFF
--- a/files/setup-03-network.sh
+++ b/files/setup-03-network.sh
@@ -20,6 +20,13 @@ DNS=${DNS_SERVER}
 Domain=${DNS_DOMAIN}
 __CUSTOMIZE_PHOTON__
 
+# Remove default symlink to prevent reverting back to local DNS stub resolver
+rm -f /etc/resolv.conf
+cat > /etc/resolv.conf <<EOF
+nameserver ${DNS_SERVER}
+search ${DNS_DOMAIN}
+EOF
+
 echo -e "\e[92mConfiguring NTP ..." > /dev/console
 cat > /etc/systemd/timesyncd.conf << __CUSTOMIZE_PHOTON__
 


### PR DESCRIPTION
Signed-off-by: William Lam <wlam@vmware.com>

## Summary

This change fixes the automatically reverting to the local DNS stub resolver address of `127.0.0.53` in `/etc/resolve.conf` which breaks local DNS resolution.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commmits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

* Closes #310 

## Testing Verification

Successfully built and deployed VEBA Appliance:

Verified `/etc/resolve.conf` does not automatically revert back to default DNS local stub address `127.0.0.53`
```
root@veba [ ~ ]# cat /etc/resolv.conf
nameserver 192.168.30.2
search primp-industries.local
```

Verified successful DNS lookup (short and FQDN)
```
root@veba [ ~ ]# nslookup vcsa
Server:		192.168.30.2
Address:	192.168.30.2#53

Name:	vcsa.primp-industries.local
Address: 192.168.30.3

root@veba [ ~ ]# nslookup vcsa.primp-industries.local
Server:		192.168.30.2
Address:	192.168.30.2#53

Name:	vcsa.primp-industries.local
Address: 192.168.30.3
```


## Additional Information

N/A