### PR TITLE
Added MM sync example

### DIFF
--- a/examples/knative/powershell/kn-ps-mm-sync/Dockerfile
+++ b/examples/knative/powershell/kn-ps-mm-sync/Dockerfile
@@ -1,0 +1,7 @@
+FROM projects.registry.vmware.com/veba/ce-ps-base:1.1
+ENV TERM linux
+ENV PORT 8080
+
+COPY handler.ps1 handler.ps1
+
+CMD ["pwsh","./server.ps1"]

--- a/examples/knative/powershell/kn-ps-mm-sync/README.md
+++ b/examples/knative/powershell/kn-ps-mm-sync/README.md
@@ -1,0 +1,42 @@
+# kn-ps-mm-vrops
+This example is a function which when a host enters Maintenance Mode in vCenter makes call to vRealize Operations Manager to mark host Maintenance Mode state.
+
+# Step 1 - Build container image
+
+Create the container images and optionally push to an external registry like GitHub Container Registry.
+
+```bash
+docker build -t <your-container-repository>/kn-ps-mm-sync-image:1.0 .
+# docker buildx build --platform linux/amd64 -t ghcr.io/darrylcauldwell/kn-ps-mm-sync-image:1.0 .
+docker push <your-container-repository>/kn-ps-mm-sync-image:1.0
+# docker push ghcr.io/darrylcauldwell/kn-ps-mm-sync-image:1.0
+```
+
+# Step 2 - Define environment variables
+
+In order to make successful call to vRealize Operations Manager environmentally specific FQDN and credentials are required. The function depends on environment variables passed as a Kubernetes secret.
+
+```bash
+# Define environment variables as secret
+
+kubectl -n vmware-functions create secret generic kn-ps-mm-sync-secret \
+  --from-literal=vropsFqdn=vrops.rainpole.local \
+  --from-literal=vropsUser=admin \
+  --from-literal=vropsPassword='DontUseThisPassword'
+```
+
+# Step 3 - Deploy
+
+```bash
+# Deploy function
+
+kubectl -n vmware-functions apply -f kn-ps-mm-sync.yml
+```
+
+# Step 4 - Undeploy
+
+```bash
+# Undeploy function
+
+kubectl -n vmware-functions delete -f kn-ps-mm-sync.yaml
+```

--- a/examples/knative/powershell/kn-ps-mm-sync/handler.ps1
+++ b/examples/knative/powershell/kn-ps-mm-sync/handler.ps1
@@ -1,0 +1,95 @@
+Function Process-Init {
+   Write-Host "$(Get-Date) - Processing Init"
+   Write-Host "$(Get-Date) - Init Processing Completed"
+   Write-Host "---------------------------"
+}
+
+Function Process-Shutdown {
+   Write-Host "$(Get-Date) - Processing Shutdown"
+   Write-Host "$(Get-Date) - Shutdown Processing Completed"
+   Write-Host "---------------------------"
+}
+
+Function Process-Handler {
+   param(
+      [Parameter(Position=0,Mandatory=$true)][CloudNative.CloudEvents.CloudEvent]$CloudEvent
+   )
+
+## Extract subject from CloudEvent object
+$eventSubject=$cloudEvent.subject
+Write-Host "$(Get-Date) - Received event from vCenter with subject" $eventSubject
+
+## Form CloudEventData object
+$cloudEventData = $cloudEvent | Read-CloudEventJsonData -ErrorAction SilentlyContinue -Depth 10
+if($cloudEventData -eq $null) {
+   $cloudEventData = $cloudEvent | Read-CloudEventData
+   }
+
+## Output CloudEventData to console for debugging
+# Write-Host "$(Get-Date) - Full contents of CloudEventData`n $(${cloudEventData} | ConvertTo-Json)`n"
+
+## Extract hostname from CloudEventData object
+$esxiHost=$cloudEventData.Host.Name
+Write-Host "$(Get-Date) - The event relates to host named" $esxiHost
+
+## Check secret in place which supplies vROps environment variables for debugging
+# Write-Host "$(Get-Date) - vropsFqdn:" ${env:vropsFqdn}
+# Write-Host "$(Get-Date) - vropsUser:" ${env:vropsUser}
+# Write-Host "$(Get-Date) - vropsPassword:" ${env:vropsPassword}
+
+## Form unauthorized headers payload
+$headers = @{
+   "Content-Type" = "application/json";
+   "Accept"  = "application/json"
+   }
+
+## Acquire bearer token
+$uri = "https://" + $env:vropsFqdn + "/suite-api/api/auth/token/acquire"
+$basicAuthBody = @{
+   username = $env:vropsUser;
+   password = $env:vropsPassword;
+   }
+$basicAuthBodyJson = $basicAuthBody | ConvertTo-Json -Depth 5
+# Write-Host "$(Get-Date) - Acquiring vROps API bearer token ..."
+$bearer = Invoke-WebRequest -Uri $uri -Method POST -Headers $headers -Body $basicAuthBodyJson -SkipCertificateCheck | ConvertFrom-Json
+
+## Output vROps API bearer token to console for debugging
+# Write-Host "$(Get-Date) - vROps API bearer token is" $bearer.token
+
+## Form authorized headers payload
+$authedHeaders = @{
+   "Content-Type" = "application/json";
+   "Accept"  = "application/json";
+   "Authorization" = "vRealizeOpsToken " + $bearer.token
+   }
+
+## Get host ResourceID
+$uri = "https://" + $env:vropsFqdn + "/suite-api/api/adapterkinds/VMWARE/resourcekinds/HostSystem/resources?name=" + $esxiHost
+# Write-Host "$(Get-Date) - Acquiring host ResourceID ..."
+$resource = Invoke-WebRequest -Uri $uri -Method GET -Headers $authedHeaders -SkipCertificateCheck
+$resourceJson = $resource.Content | ConvertFrom-Json
+
+## Output vROps ResourceID of host to console for debugging
+# Write-Host "$(Get-Date) - ResourceID of host is " $resourceJson.resourceList[0].identifier
+
+## Call API to mark host maintenance mode state
+$uri = "https://" + $env:vropsFqdn + "/suite-api/api/resources/" + $resourceJson.resourceList[0].identifier + "/maintained"
+
+
+If ( $eventSubject -eq 'EnteredMaintenanceModeEvent'){
+   Write-Host "$(Get-Date) - Attempting to mark host in vROps as being in maintenance mode ..."
+   Invoke-WebRequest -Uri $uri -Method PUT -Headers $authedHeaders -SkipCertificateCheck
+   }
+If ( $eventSubject -eq 'ExitMaintenanceModeEvent'){
+   Write-Host "$(Get-Date) - Attempting to mark host in vROps as not being in maintenance mode ..."
+   Invoke-WebRequest -Uri $uri -Method DELETE -Headers $authedHeaders -SkipCertificateCheck
+   }
+
+## Get host maintenance mode state
+$uri = "https://" + $env:vropsFqdn + "/suite-api/api/adapterkinds/VMWARE/resourcekinds/HostSystem/resources?name=" + $esxiHost
+# Write-Host "Checking vROps host maintenance mode state ..."
+$resource = Invoke-WebRequest -Uri $uri -Method GET -Headers $authedHeaders -SkipCertificateCheck
+$resourceJson = $resource.Content | ConvertFrom-Json
+Write-Host "$(Get-Date) -" $esxiHost "vROps maintenence mode state is now " $resourceJson.resourceList[0].resourceStatusStates[0].resourceState "( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )"
+Write-Host "---------------------------"
+}

--- a/examples/knative/powershell/kn-ps-mm-sync/kn-ps-mm-sync.yml
+++ b/examples/knative/powershell/kn-ps-mm-sync/kn-ps-mm-sync.yml
@@ -1,0 +1,57 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: kn-ps-mm-sync-service
+  labels:
+    app: veba-ui
+  namespace: vmware-functions
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: "1"
+        autoscaling.knative.dev/minScale: "1"
+    spec:
+      containers:
+        - image: ghcr.io/darrylcauldwell/kn-ps-mm-sync-image:1.0
+          envFrom:
+            - secretRef:
+                name: kn-ps-mm-sync-secret
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: kn-ps-mm-sync-enter-trigger
+  labels:
+    app: veba-ui
+  namespace: vmware-functions
+spec:
+  broker: default
+  filter:
+    attributes:
+        type: com.vmware.event.router/event
+        subject: EnteredMaintenanceModeEvent
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: kn-ps-mm-sync-service
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: kn-ps-mm-sync-exit-trigger
+  labels:
+    app: veba-ui
+  namespace: vmware-functions
+spec:
+  broker: default
+  filter:
+    attributes:
+        type: com.vmware.event.router/event
+        subject: ExitMaintenanceModeEvent
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: kn-ps-mm-sync-service


### PR DESCRIPTION
## Summary

Addition of Knative Powershell example to sync vCenter maintenance mode state with vROps.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [x] Please include any relevant screenshots and/or output as part of your testing
- [x] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [x] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

Closes #ISSUE-NUMBER

## Testing Verification

* Short summary of testing (e.g. successfully built and deployed VMware Event Broker Appliance)
* Please include any relevant screenshots and/or output as part of the testing

Tested with VEBA appliance release 0.6.1,  output from testing

```console
kubectl logs -n vmware-functions kn-ps-mm-sync-service-00001-deployment-585cb689d8-j2nqw user-container --follow
06/23/2021 15:32:17 - PowerShell HTTP server start listening on 'http://*:8080/'
06/23/2021 15:32:17 - Processing Init
06/23/2021 15:32:17 - Init Processing Completed
---------------------------
06/23/2021 15:32:48 - Received event from vCenter with subject ExitMaintenanceModeEvent
06/23/2021 15:32:48 - The event relates to host named 192.168.1.13
06/23/2021 15:32:48 - Attempting to mark host in vROps as not being in maintenance mode ...
06/23/2021 15:32:48 - 192.168.1.13 vROps maintenence mode state is now  STARTED ( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )
---------------------------
06/23/2021 15:32:53 - Received event from vCenter with subject EnteredMaintenanceModeEvent
06/23/2021 15:32:53 - The event relates to host named 192.168.1.13
06/23/2021 15:32:54 - Attempting to mark host in vROps as being in maintenance mode ...
06/23/2021 15:32:54 - 192.168.1.13 vROps maintenence mode state is now  MAINTAINED_MANUAL ( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )
---------------------------
06/23/2021 15:32:56 - Received event from vCenter with subject ExitMaintenanceModeEvent
06/23/2021 15:32:56 - The event relates to host named 192.168.1.13
06/23/2021 15:32:57 - Attempting to mark host in vROps as not being in maintenance mode ...
06/23/2021 15:32:57 - 192.168.1.13 vROps maintenence mode state is now  STARTED ( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )
---------------------------
06/23/2021 15:33:04 - Received event from vCenter with subject EnteredMaintenanceModeEvent
06/23/2021 15:33:04 - The event relates to host named 192.168.1.13
06/23/2021 15:33:05 - Attempting to mark host in vROps as being in maintenance mode ...
06/23/2021 15:33:05 - 192.168.1.13 vROps maintenence mode state is now  MAINTAINED_MANUAL ( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )
---------------------------
06/23/2021 15:39:47 - Received event from vCenter with subject ExitMaintenanceModeEvent
06/23/2021 15:39:47 - The event relates to host named 192.168.1.13
06/23/2021 15:39:47 - Attempting to mark host in vROps as not being in maintenance mode ...
06/23/2021 15:39:47 - 192.168.1.13 vROps maintenence mode state is now  STARTED ( STARTED=Not In Maintenance | MAINTAINED_MANUAL=In Maintenance )
---------------------------
```

## Additional Information

* Any other details you wish to include or mention

If you have any questions/comments, feel free to reach out to team on Slack [#vcenter-event-broker-appliance](https://vmwarecode.slack.com/archives/CQLT9B5AA)

Thank you from the VEBA Team! 🥳