### PR TITLE
Add resource usage and performance monitoring feature

### DIFF
--- a/files/eventbridge-ingressroute-gateway.yaml
+++ b/files/eventbridge-ingressroute-gateway.yaml
@@ -36,4 +36,21 @@ spec:
     tls:
       minimumProtocolVersion: "1.2"
       secretName: ##CERT_NAME##
-status: {}
+  includes:
+  - name: cadvisor
+    namespace: vmware-system
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  routes:
+  - conditions:
+    - prefix: /top
+    services:
+    - name: cadvisor
+      port: 8080

--- a/files/knative-embedded-ingressroute-gateway.yaml
+++ b/files/knative-embedded-ingressroute-gateway.yaml
@@ -41,6 +41,8 @@ spec:
   includes:
   - name: sockeye
     namespace: vmware-functions
+  - name: cadvisor
+    namespace: vmware-system
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -73,3 +75,20 @@ spec:
     services:
     - name: sockeye
       port: 80
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: contour-external
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  routes:
+  - conditions:
+    - prefix: /top
+    services:
+    - name: cadvisor
+      port: 8080

--- a/files/knative-embedded-veba-ui-ingressroute-gateway.yaml
+++ b/files/knative-embedded-veba-ui-ingressroute-gateway.yaml
@@ -46,6 +46,8 @@ spec:
   includes:
   - name: sockeye
     namespace: vmware-functions
+  - name: cadvisor
+    namespace: vmware-system
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -78,3 +80,20 @@ spec:
     services:
     - name: sockeye
       port: 80
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: contour-external
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  routes:
+  - conditions:
+    - prefix: /top
+    services:
+    - name: cadvisor
+      port: 8080

--- a/files/knative-external-ingressroute-gateway.yaml
+++ b/files/knative-external-ingressroute-gateway.yaml
@@ -36,3 +36,18 @@ spec:
     tls:
       minimumProtocolVersion: "1.2"
       secretName: ##CERT_NAME##
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  routes:
+  - conditions:
+    - prefix: /top
+    services:
+    - name: cadvisor
+      port: 8080

--- a/files/openfaas-ingressroute-gateway.yaml
+++ b/files/openfaas-ingressroute-gateway.yaml
@@ -41,7 +41,11 @@ spec:
     tls:
       minimumProtocolVersion: "1.2"
       secretName: ##CERT_NAME##
-status: {}
+  includes:
+  - name: gateway
+    namespace: openfaas
+  - name: cadvisor
+    namespace: vmware-system
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -55,4 +59,18 @@ spec:
     services:
     - name: gateway
       port: 8080
-status: {}
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  routes:
+  - conditions:
+    - prefix: /top
+    services:
+    - name: cadvisor
+      port: 8080

--- a/files/setup-012-cadvisor.sh
+++ b/files/setup-012-cadvisor.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Copyright 2019 VMware, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2
+
+# Setup Google cAdvisor
+
+set -euo pipefail
+
+# Retrieve the cAdvisor image
+VEBA_BOM_FILE=/root/config/veba-bom.json
+CADVISOR_IMAGE=$(jq -r < ${VEBA_BOM_FILE} '.["cadvisor"].containers[0].name')
+CADVISOR_VERSION=$(jq -r < ${VEBA_BOM_FILE} '.["cadvisor"].containers[0].version')
+
+echo -e "\e[92mDeploying cAdvisor ..." > /dev/console
+
+cat > /root/config/cadvisor-preperations.yaml << __CADVISOR_PREPERATIONS__
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - cadvisor
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cadvisor
+subjects:
+- kind: ServiceAccount
+  name: cadvisor
+  namespace: vmware-system
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  allowedHostPaths:
+  - pathPrefix: "/"
+  - pathPrefix: "/var/run"
+  - pathPrefix: "/sys"
+  - pathPrefix: "/var/lib/docker"
+  - pathPrefix: "/dev/disk"
+__CADVISOR_PREPERATIONS__
+
+cat > /root/config/cadvisor-ds.yaml << __CADVISOR_DS__
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+  annotations:
+      seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  selector:
+    matchLabels:
+      app: cadvisor
+  template:
+    metadata:
+      labels:
+        app: cadvisor
+    spec:
+      serviceAccountName: cadvisor
+      containers:
+      - name: cadvisor
+        image: ${CADVISOR_IMAGE}:${CADVISOR_VERSION}
+        resources:
+          requests:
+            memory: 400Mi
+            cpu: 400m
+          limits:
+            memory: 2000Mi
+            cpu: 800m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+        args:
+         - --url_base_prefix=/top
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk
+__CADVISOR_DS__
+
+cat > /root/config/cadvisor-svc.yaml << __CADVISOR_SVC__
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cadvisor
+  name: cadvisor
+  namespace: vmware-system
+spec:
+  selector:
+    app: cadvisor
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  sessionAffinity: None
+__CADVISOR_SVC__
+
+kubectl apply -f /root/config/cadvisor-preperations.yaml
+kubectl apply -f /root/config/cadvisor-ds.yaml
+kubectl apply -f /root/config/cadvisor-svc.yaml
+kubectl wait --for=condition=ready pod -l app=cadvisor --timeout=3m -n vmware-system

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -117,6 +117,9 @@ else
 		. /root/setup/setup-011-fluentbit.sh
 	fi
 
+	echo -e "\e[92mStarting cAdvisor Configuration ..." > /dev/console
+	. /root/setup/setup-012-cadvisor.sh
+
 	echo -e "\e[92mStarting OS Banner Configuration ..."> /dev/console
 	. /root/setup/setup-099-banner.sh &
 

--- a/photon.json
+++ b/photon.json
@@ -157,6 +157,11 @@
     },
     {
       "type": "file",
+      "source": "files/setup-012-cadvisor.sh",
+      "destination": "/root/setup/setup-012-cadvisor.sh"
+    },
+    {
+      "type": "file",
       "source": "files/setup-099-banner.sh",
       "destination": "/root/setup/setup-099-banner.sh"
     },

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -37,10 +37,16 @@
     "fluentbit": {
         "gitRepoTag": "v1.7.9",
         "containers": [{
-            "name": "fluent/fluent-bit",
-            "version": "1.7.9"
-            }
-        ]
+                "name": "fluent/fluent-bit",
+                "version": "1.7.9"
+            }]
+    },
+    "cadvisor": {
+        "gitRepoTag": "v0.37.5",
+        "containers": [{
+                "name": "gcr.io/cadvisor/cadvisor",
+                "version": "v0.37.5"
+            }]
     },
     "kubernetes": {
         "gitRepoTag": "v1.20.2",


### PR DESCRIPTION

Signed-off-by: Robert Guske <rguske@vmware.com>

## Summary

This PR will make cAdvisor an integral part of VEBA and will give customers a new url (`https://veba-fqdn/top`) to see resource usage and utilization. It will also improve support for Day-2 operations by providing an endpoint to which external monitoring solutions can connect to.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [x] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

Closes #450

## Testing Verification

* successfully built and deployed VMware Event Broker Appliance
* validated the functional state of the cAdvisor deployment as well as the corresponding `httpproxy` configuration for the event processors Knative and OpenFaaS.

**Knative deployment:**

```
root@veba-kn [ ~ ]# kubectl get httpproxy -A
NAMESPACE          NAME           FQDN                 TLS SECRET        STATUS   STATUS DESCRIPTION
vmware-functions   sockeye                                               valid    Valid HTTPProxy
vmware-system      cadvisor                                              valid    Valid HTTPProxy
vmware-system      event-router   veba-kn.jarvis.lab   eventrouter-tls   valid    Valid HTTPProxy


root@veba-kn [ ~ ]# kubectl -n vmware-system get svc
NAME                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
cadvisor              ClusterIP   10.109.183.31    <none>        31194/TCP            106s
tinywww               ClusterIP   10.110.162.247   <none>        8100/TCP             109s
veba-rabbit           ClusterIP   10.100.109.110   <none>        15672/TCP,5672/TCP   2m37s
veba-rabbit-nodes     ClusterIP   None             <none>        4369/TCP,25672/TCP   2m37s
vmware-event-router   ClusterIP   10.111.51.26     <none>        8082/TCP             2m39s

root@veba-kn [ ~ ]# kubectl get ns | grep "knative"
knative-eventing     Active   5m5s
knative-serving      Active   6m21s
```

**OpenFaaS deployment**

```
root@veba-of [ ~ ]# kubectl get pods -A
NAMESPACE        NAME                                         READY   STATUS      RESTARTS   AGE
kube-system      antrea-agent-p5s25                           2/2     Running     0          19m
kube-system      antrea-controller-849fff8c5d-xlgpk           1/1     Running     0          19m
kube-system      coredns-74ff55c5b-6swnn                      1/1     Running     0          19m
kube-system      coredns-74ff55c5b-fq4lw                      1/1     Running     0          19m
kube-system      etcd-veba-of.jarvis.lab                      1/1     Running     0          19m
kube-system      kube-apiserver-veba-of.jarvis.lab            1/1     Running     0          19m
kube-system      kube-controller-manager-veba-of.jarvis.lab   1/1     Running     0          19m
kube-system      kube-proxy-9b4xh                             1/1     Running     0          19m
kube-system      kube-scheduler-veba-of.jarvis.lab            1/1     Running     0          19m
openfaas         alertmanager-8697588d84-9dd6z                1/1     Running     0          19m
openfaas         basic-auth-plugin-858495b9c6-skm6z           1/1     Running     0          19m
openfaas         gateway-5dd7fd4dc4-sg55k                     2/2     Running     1          19m
openfaas         nats-cdc589ff7-zfn57                         1/1     Running     0          19m
openfaas         prometheus-7c6b97c87f-82r8l                  1/1     Running     0          19m
openfaas         queue-worker-749c7964f4-wrc6b                1/1     Running     1          19m
projectcontour   contour-77f4759d86-jjf8t                     1/1     Running     0          19m
projectcontour   contour-77f4759d86-nkvdc                     1/1     Running     0          19m
projectcontour   contour-certgen-v1.9.0-b8gcd                 0/1     Completed   0          19m
projectcontour   envoy-tb82d                                  2/2     Running     0          19m
vmware-system    cadvisor-htj94                               1/1     Running     0          19m
vmware-system    tinywww-dd88dc7db-4nnvj                      1/1     Running     0          19m
vmware-system    vmware-event-router-9c79cd5fd-sbrg6          1/1     Running     2          19m

root@veba-of [ ~ ]# kubectl get httpproxy -A
NAMESPACE       NAME           FQDN                 TLS SECRET        STATUS   STATUS DESCRIPTION
openfaas        gateway                                               valid    Valid HTTPProxy
vmware-system   cadvisor                                              valid    Valid HTTPProxy
vmware-system   event-router   veba-of.jarvis.lab   eventrouter-tls   valid    Valid HTTPProxy
```

* validated the new exposed `/top` website

![veba-cadvisor-page](https://user-images.githubusercontent.com/31652019/123128451-7249b180-d44b-11eb-91ae-607ea08f15e1.png)


## Additional Information

N/A