### PR TITLE
Fix processing simultaneous requested events from different sources

### DIFF
--- a/examples/knative/templates/server.ps1
+++ b/examples/knative/templates/server.ps1
@@ -1,9 +1,10 @@
-if(${env:PORT}) {
-   $url = "http://*:${env:PORT}/"
-   $localUrl = "http://localhost:${env:PORT}/"
-} else {
-   $url = "http://*:8080/"
-   $localUrl = "http://localhost:8080/"
+if (${env:PORT}) {
+    $url = "http://*:${env:PORT}/"
+    $localUrl = "http://localhost:${env:PORT}/"
+}
+else {
+    $url = "http://*:8080/"
+    $localUrl = "http://localhost:8080/"
 }
 
 $serverStopMessage = 'break-signal-e2db683c-b8ff-4c4f-8158-c44f734e2bf1'
@@ -11,131 +12,163 @@ $serverStopMessage = 'break-signal-e2db683c-b8ff-4c4f-8158-c44f734e2bf1'
 . ./handler.ps1
 
 $backgroundServer = Start-ThreadJob {
-   param($url, $serverStopMessage)
+    param($url, $serverStopMessage)
 
-   Import-Module 'Microsoft.PowerShell.Utility'
-   Import-Module CloudEvents.Sdk
+    Import-Module 'Microsoft.PowerShell.Utility'
+    Import-Module CloudEvents.Sdk
 
-   . ./handler.ps1
+    . ./handler.ps1
 
-   function Start-HttpCloudEventListener {
-   <#
-      .DESCRIPTION
-      Starts a HTTP Listener on specified Url
-   #>
+    function Start-HttpCloudEventListener {
+        <#
+        .SYNOPSIS
+        Starts a HTTP listener on specified Url
 
-   [CmdletBinding()]
-   param(
-      [Parameter(
-         Mandatory = $true,
-         ValueFromPipeline = $false,
-         ValueFromPipelineByPropertyName = $false)]
-      [ValidateNotNull()]
-      [string]
-      $Url
-   )
+        .DESCRIPTION
+        Starts a HTTP listener and processes requests sequentially using the listener's context in an infinite loop.
+        The listener stops graefully on $serverStopMessage request.
 
-      $listener = New-Object -Type 'System.Net.HttpListener'
-      $listener.AuthenticationSchemes = [System.Net.AuthenticationSchemes]::Anonymous
-      $listener.Prefixes.Add($Url)
+        .PARAMETER Url
+        Specifies which Url the HTTP listener should process
 
-      $cloudEvent = $null
+        .OUTPUTS
+        Boolean $true when setver stop request is received, otherwise $null.
+        #>
 
-      try {
-         $listener.Start()
-         $context = $listener.GetContext()
+        [CmdletBinding()]
+        param(
+            [Parameter(
+                Mandatory = $true,
+                ValueFromPipeline = $false,
+                ValueFromPipelineByPropertyName = $false)]
+            [ValidateNotNull()]
+            [string]
+            $Url
+        )
 
-         try {
-            # Read Input Stream
-            $buffer = New-Object 'byte[]' -ArgumentList 1024
-            $ms = New-Object 'IO.MemoryStream'
-            $read = 0
-            while (($read = $context.Request.InputStream.Read($buffer, 0, 1024)) -gt 0) {
-               $ms.Write($buffer, 0, $read);
+        $listener = New-Object -Type 'System.Net.HttpListener'
+        $listener.AuthenticationSchemes = [System.Net.AuthenticationSchemes]::Anonymous
+        $listener.Prefixes.Add($Url)
+
+        $cloudEvent = $null
+
+        try {
+            $listener.Start()
+
+            while ($true) {
+                $context = $listener.GetContext()
+
+                try {
+                    # Read Input Stream
+                    $buffer = New-Object 'byte[]' -ArgumentList 1024
+                    $ms = New-Object 'IO.MemoryStream'
+                    $read = 0
+                    while (($read = $context.Request.InputStream.Read($buffer, 0, 1024)) -gt 0) {
+                        $ms.Write($buffer, 0, $read);
+                    }
+                    $bodyData = $ms.ToArray()
+                    $ms.Dispose()
+
+                    # Read Headers
+                    $headers = @{}
+                    for ($i = 0; $i -lt $context.Request.Headers.Count; $i++) {
+                        $headers[$context.Request.Headers.GetKey($i)] = $context.Request.Headers.GetValues($i)
+                    }
+
+                    $cloudEvent = ConvertFrom-HttpMessage -Headers $headers -Body $bodyData
+
+                    if ([System.Text.Encoding]::UTF8.GetString($bodyData) -eq $serverStopMessage) {
+                        # Server Stop request
+                        $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::OK)
+                        $context.Response.Close();
+
+                        # Runs Shutdown function (defined in handler.ps1) to clean up connections from warm startup
+                        try {
+                            Process-Shutdown
+                        }
+                        catch {
+                            Write-Error "`n$(Get-Date) - Shutdown Processing Error: $($_.Exception.ToString())"
+                        }
+
+                        # Set function result
+                        $true
+                        # Break the infinite loop
+                        break
+                    }
+
+                    if ( $cloudEvent -ne $null ) {
+                        try {
+                            Process-Handler -CloudEvent $cloudEvent | Out-Null
+                            $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::OK)
+                        }
+                        catch {
+                            Write-Error "$(Get-Date) - Handler Processing Error: $($_.Exception.ToString())"
+                            # TODO: Consider returning more specific HTTP status based on the Process-Handler error.
+                            # The handler interface could be extended to provide expectations fot the event and to return HTTP 4xx.
+
+                            $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::InternalServerError)
+                        }
+                    }
+
+                }
+                catch {
+                    Write-Error "`n$(Get-Date) - HTTP Request Processing Error: $($_.Exception.ToString())"
+                    # TODO: Consider returning more specific HTTP status based on the exception.
+                    # If the comes from CloudEvents SDK regarding the cloud event formatting the error might be 4xx
+
+                    $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::InternalServerError)
+                }
+                finally {
+                    $context.Response.Close();
+                }
             }
-            $bodyData = $ms.ToArray()
-            $ms.Dispose()
+        }
+        catch {
+            Write-Error "$(Get-Date) - Listener Processing Error: $($_.Exception.ToString())"
+            exit 1
+        }
+        finally {
+            $listener.Stop()
+        }
+    }
 
-            # Read Headers
-            $headers = @{}
-            for($i =0; $i -lt $context.Request.Headers.Count; $i++) {
-               $headers[$context.Request.Headers.GetKey($i)] = $context.Request.Headers.GetValues($i)
-            }
+    # Runs Init function (defined in handler.ps1) which can be used to enable warm startup
+    try {
+        Process-Init
+    }
+    catch {
+        Write-Error "$(Get-Date) - Init Processing Error: $($_.Exception.ToString())"
+        exit 1
+    }
 
-            $cloudEvent = ConvertFrom-HttpMessage -Headers $headers -Body $bodyData
-
-            # function result
-            ([System.Text.Encoding]::UTF8.GetString($bodyData) -eq $serverStopMessage)
-
-            if ( $cloudEvent -ne $null ) {
-               try {
-                  Process-Handler -CloudEvent $cloudEvent | Out-Null
-                  $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::OK)
-               } catch {
-                  Write-Error "$(Get-Date) - Handler Processing Error: $($_.Exception.ToString())"
-                  $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::InternalServerError)
-               }
-            }
-
-         } catch {
-            Write-Error "`n$(Get-Date) - HTTP Request Processing Error: $($_.Exception.ToString())"
-            $context.Response.StatusCode = [int]([System.Net.HttpStatusCode]::InternalServerError)
-         } finally {
-            $context.Response.Close();
-         }
-
-      } catch {
-         Write-Error "$(Get-Date) - Listener Processing Error: $($_.Exception.ToString())"
-         exit 1
-      } finally {
-         $listener.Stop()
-      }
-   }
-
-   # Runs Init function (defined in handler.ps1) which can be used to enable warm startup
-   try {
-      Process-Init
-   } catch {
-      Write-Error "$(Get-Date) - Init Processing Error: $($_.Exception.ToString())"
-      exit 1
-   }
-
-   while($true) {
-      $breakSignal = Start-HttpCloudEventListener -Url $url
-      if ($breakSignal) {
-         Write-Host "$(Get-Date) - PowerShell HTTP server stop requested"
-         break;
-      }
-   }
+    $breakSignal = Start-HttpCloudEventListener -Url $url
+    if ($breakSignal) {
+        Write-Host "$(Get-Date) - PowerShell HTTP server stop requested"
+        break;
+    }
 } -ArgumentList $url, $serverStopMessage
 
 $killEvent = new-object 'System.Threading.AutoResetEvent' -ArgumentList $false
 
-$serverTerminateJob = Start-ThreadJob {
-param($killEvent, $url, $serverStopMessage)
-   $killEvent.WaitOne() | Out-Null
-   Invoke-WebRequest -Uri $url -Body $serverStopMessage | Out-Null
+Start-ThreadJob {
+    param($killEvent, $url, $serverStopMessage)
+    $killEvent.WaitOne() | Out-Null
+    Invoke-WebRequest -Uri $url -Body $serverStopMessage | Out-Null
 } -ArgumentList $killEvent, $localUrl, $serverStopMessage
 
 try {
-   Write-Host "$(Get-Date) - PowerShell HTTP server start listening on '$url'"
-   $running = $true
-   while($running) {
-      Start-Sleep  -Milliseconds 100
-      $running = ($backgroundServer.State -eq 'Running')
-      $backgroundServer = $backgroundServer | Get-Job
-      $backgroundServer | Receive-Job
-   }
-} finally {
-   Write-Host "$(Get-Date) - PowerShell HTTP Server stop requested. Waiting for server to stop"
-   $killEvent.Set() | Out-Null
-   Get-Job | Wait-Job | Receive-Job
-   Write-Host "$(Get-Date) - PowerShell HTTP server is stopped"
-
-   # Runs Shutdown function (defined in handler.ps1) to clean up connections from warm startup
-   try {
-      Process-Shutdown
-   } catch {
-      Write-Error "`n$(Get-Date) - Shutdown Processing Error: $($_.Exception.ToString())"
-   }
+    Write-Host "$(Get-Date) - PowerShell HTTP server start listening on '$url'"
+    $running = $true
+    while ($running) {
+        Start-Sleep  -Milliseconds 100
+        $running = ($backgroundServer.State -eq 'Running')
+        $backgroundServer = $backgroundServer | Get-Job
+        $backgroundServer | Receive-Job
+    }
+}
+finally {
+    Write-Host "$(Get-Date) - PowerShell HTTP Server stop requested. Waiting for server to stop"
+    $killEvent.Set() | Out-Null
+    Get-Job | Wait-Job | Receive-Job
+    Write-Host "$(Get-Date) - PowerShell HTTP server is stopped"
 }


### PR DESCRIPTION
Signed-off-by: Dimitar Milov <dmilov@vmware.com>

## Summary
Improves the server.ps1 implementation with tha ability to process multiple events sent simulteniously.
Addresses issue #495 

- HttpListener is opened only once at the beginning
- HttpListener is closed only when server stop request is received (usually by process SIGTERM)
- HTTP Requests are enqueued and processed one by one allowing multiple simultenious requests to the server to be sent.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [x] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

Closes #495 

## Testing Verification

* Short summary of testing (e.g. successfully built and deployed VMware Event Broker Appliance)
* Please include any relevant screenshots and/or output as part of the testing
Tested ps server with a handler that simulates processing with sleep of 5 sedonds. 
- Ran 3 events in sequence and 3 event in parallel. 
Before the applied fixes the two of the parallel sent event were dropped by the server.
After the fixes all events are processed by the handler.
- Ctrl+C in the server process successfully terminates the server

![image](https://user-images.githubusercontent.com/10736688/126754477-9c37c04d-fd66-4221-848f-04644bc729f1.png)

The testing code is available in the https://github.com/dmilov/vcenter-event-broker-appliance/tree/topic/ps-server-testing

## Additional Information

* Any other details you wish to include or mention

If you have any questions/comments, feel free to reach out to team on Slack [#vcenter-event-broker-appliance](https://vmwarecode.slack.com/archives/CQLT9B5AA)

Thank you from the VEBA Team! 🥳