### PR TITLE
fix: Fix settings process exit code in server.ps1

### DIFF
--- a/examples/knative/templates/server.ps1
+++ b/examples/knative/templates/server.ps1
@@ -127,7 +127,7 @@ $backgroundServer = Start-ThreadJob {
         }
         catch {
             Write-Error "$(Get-Date) - Listener Processing Error: $($_.Exception.ToString())"
-            exit 1
+            [Environment]::Exit(1)
         }
         finally {
             $listener.Stop()
@@ -140,7 +140,7 @@ $backgroundServer = Start-ThreadJob {
     }
     catch {
         Write-Error "$(Get-Date) - Init Processing Error: $($_.Exception.ToString())"
-        exit 1
+        [Environment]::Exit(1)
     }
 
     $breakSignal = Start-HttpCloudEventListener -Url $url

--- a/examples/knative/templates/test/process-init-error-handler.ps1
+++ b/examples/knative/templates/test/process-init-error-handler.ps1
@@ -1,0 +1,16 @@
+ function Process-Init {
+    [CmdletBinding()]
+    param()
+
+    throw "Process-Init Error"
+ }
+
+function Process-Handler {
+    [CmdletBinding()]
+    param()
+}
+
+function Process-Shutdown {
+    [CmdletBinding()]
+    param()
+}

--- a/examples/knative/templates/test/server-test-helper.ps1
+++ b/examples/knative/templates/test/server-test-helper.ps1
@@ -1,0 +1,39 @@
+function Start-ServerProcess {
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateScript({Test-Path $_})]
+        $HandlerPath
+    )
+
+    Get-Content $HandlerPath -Raw | Set-Content "./handler.ps1"
+    $powershellProcessName = (Get-Process -Id $pid).ProcessName
+
+    $serverScriptPath = (Join-Path ($PSScriptRoot | Split-Path) 'server.ps1')
+
+    $script:serverProcess = Start-Process `
+        -FilePath $powershellProcessName `
+        -ArgumentList @('-c', "$serverScriptPath") `
+        -PassThru
+
+}
+
+
+
+function Wait-ServerExit {
+    $MAX_PROCESS_RUTIME_SECONDS = 60
+
+    $serverProcessRuntimeMs = 0
+    $iterationTimeoutMs = 300
+    while (-not $script:serverProcess.HasExited -and `
+           ($serverProcessRuntimeMs / 1000) -lt $MAX_PROCESS_RUTIME_SECONDS) {
+        Start-Sleep -Milliseconds 300
+        $serverProcessRuntimeMs += 300
+    }
+
+    if (($serverProcessRuntimeMs / 1000) -gt $MAX_PROCESS_RUTIME_SECONDS ) {
+        throw "Server process time out"
+    }
+
+    # return server exit code    
+    $script:serverProcess.ExitCode
+}

--- a/examples/knative/templates/test/server.tests.ps1
+++ b/examples/knative/templates/test/server.tests.ps1
@@ -1,0 +1,32 @@
+Describe "server.ps1 tests" {
+    Context "Termination on error" {
+        BeforeAll {
+            $env:UNIT_TEST_SERVER = "http://localhost:52474/"
+
+            . (Join-Path $PSScriptRoot 'server-test-helper.ps1')
+
+            # set current folder to ensure handler.ps1 is loded by the server.ps1
+            Push-Location $PSScriptRoot
+        }
+
+        AfterAll {
+            if (Test-Path "./handler.ps1") {
+                Remove-Item "./handler.ps1" -Confirm:$false
+            }
+            Pop-Location
+
+            $env:PORT = $null
+        }
+
+        It "Should handle error in Process-Init and exit the server process with exit code 1" {
+            # Arrange
+            Start-ServerProcess -HandlerPath (Join-Path $PSScriptRoot 'process-init-error-handler.ps1')
+
+            # Act
+            $exitCode = Wait-ServerExit
+
+            # Assert
+            $exitCode | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Dimitar Milov <dmilov@vmware.com>

## Summary

Fix setting exit code for a `pwsh` process. Using the keyword `exit` doesn't set the process exit code when it is called from a worker thread. Using the .NET `System.Environment` `Exit` method works. It correctly sets the process exit code when called in a worker thread.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

Closes #578

## Testing Verification
Tested exit code in isolation of VEBA on Windows and Photon OS container
Server code
```
$backgroundServer = Start-ThreadJob {

    Start-Sleep -Seconds 1
    [Environment]::Exit(1)
}

$running = $true
while ($running) {
    Start-Sleep  -Milliseconds 100
    $running = ($backgroundServer.State -eq 'Running')
    $backgroundServer = $backgroundServer | Get-Job
}
```

Test
```
>$pi = Start-Process -FilePath pwsh -ArgumentList '-c', '/root/testserver.ps1' -PassThru
>$pi.ExitCode
1
```

## Additional Information

* Any other details you wish to include or mention

If you have any questions/comments, feel free to reach out to team on Slack [#vcenter-event-broker-appliance](https://vmwarecode.slack.com/archives/CQLT9B5AA)

Thank you from the VEBA Team! 🥳