### PR TITLE
Migrate container runtime from Docker to Containerd

### DIFF
--- a/docs/kb/install-knative.md
+++ b/docs/kb/install-knative.md
@@ -95,7 +95,6 @@ Deploy the VMware Event Broker Appliance OVA to your vCenter Server using the vS
 
 #### **zAdvanced** (Optional)
   * Debugging - When enabled, this will output a more verbose log file that can be used to troubleshoot failed deployments
-  * Docker Bridge CIDR Network - Customize Docker Bridge CIDR Network (Default 172.17.0.1/16)
   * POD CIDR Network - Customize POD CIDR Network (Default 10.99.0.0/20). Must not overlap with the appliance IP address
 
 ### Step 3

--- a/files/configs/kubernetes/templates/kubeconfig-template.yaml
+++ b/files/configs/kubernetes/templates/kubeconfig-template.yaml
@@ -13,3 +13,7 @@ kind: ClusterConfiguration
 kubernetesVersion: #@ version
 networking:
   podSubnet: #@ cidr
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+cgroupDriver: system

--- a/files/setup-01-os.sh
+++ b/files/setup-01-os.sh
@@ -14,24 +14,8 @@ else
     systemctl stop sshd
 fi
 
-# Ensure docker is stopped to allow config of network/proxies
-systemctl stop docker
-
 echo -e "\e[92mConfiguring OS Root password ..." > /dev/console
 echo "root:${ROOT_PASSWORD}" | /usr/sbin/chpasswd
-
-if [ "${DOCKER_NETWORK_CIDR}" != "172.17.0.1/16" ]; then
-    echo -e "\e[92mConfiguring Docker Bridge Network ..." > /dev/console
-    cat > /etc/docker/daemon.json << EOF
-{
-    "bip": "${DOCKER_NETWORK_CIDR}",
-    "log-opts": {
-       "max-size": "10m",
-       "max-file": "5"
-    }
-}
-EOF
-fi
 
 echo -e "\e[92mConfiguring IP Tables for Antrea ..." > /dev/console
 iptables -A INPUT -i gw0 -j ACCEPT

--- a/files/setup-02-proxy.sh
+++ b/files/setup-02-proxy.sh
@@ -2,17 +2,16 @@
 # Copyright 2021 VMware, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2
 
-# Setup Network Proxy for both OS and Docker
+# Setup Network Proxy for both OS and Containerd
 
 set -euo pipefail
 
 if [ -n "${HTTP_PROXY}" ] || [ -n "${HTTPS_PROXY}" ]; then
     PROXY_CONF=/etc/sysconfig/proxy
-    DOCKER_PROXY=/etc/systemd/system/docker.service.d
+    CONTAINERD_CONF=/usr/lib/systemd/system/containerd.service
 
     echo -e "\e[92mConfiguring Proxy ..." > /dev/console
     echo "PROXY_ENABLED=\"yes\"" > ${PROXY_CONF}
-    mkdir -p ${DOCKER_PROXY}
     YES_CREDS=0
     if [ -n "${PROXY_USERNAME}" ] && [ -n "${PROXY_PASSWORD}" ]; then
         YES_CREDS=1
@@ -20,6 +19,7 @@ if [ -n "${HTTP_PROXY}" ] || [ -n "${HTTPS_PROXY}" ]; then
 
     if [ ! -z "${NO_PROXY}" ]; then
         echo "NO_PROXY=\"${NO_PROXY}\"" >> ${PROXY_CONF}
+        sed -i "/^\[Install\]/i Environment=NO_PROXY=${NO_PROXY}" ${CONTAINERD_CONF}
     fi
 
     if [ ! -z "${HTTP_PROXY}" ]; then
@@ -33,10 +33,7 @@ if [ -n "${HTTP_PROXY}" ] || [ -n "${HTTPS_PROXY}" ]; then
                 HTTP_PROXY_URL="${HTTP_PROXY_PROTOCOL}://${HTTP_PROXY_SERVER_PORT}"
             fi
             echo "HTTP_PROXY=\"${HTTP_PROXY_URL}\"" >> ${PROXY_CONF}
-            cat > ${DOCKER_PROXY}/http-proxy.conf << __HTTP_DOCKER_PROXY__
-[Service]
-Environment="HTTP_PROXY=${HTTP_PROXY_URL}" "NO_PROXY=${NO_PROXY}"
-__HTTP_DOCKER_PROXY__
+            sed -i "/^\[Install\]/i Environment=HTTP_PROXY=${HTTP_PROXY_URL}" ${CONTAINERD_CONF}
         else
 	    echo -e "\e[91mInvalid HTTP Proxy URL supplied" > /dev/console
         fi
@@ -53,10 +50,7 @@ __HTTP_DOCKER_PROXY__
                 HTTPS_PROXY_URL="${HTTPS_PROXY_PROTOCOL}://${HTTPS_PROXY_SERVER_PORT}"
             fi
             echo "HTTPS_PROXY=\"${HTTPS_PROXY_URL}\"" >> ${PROXY_CONF}
-            cat > ${DOCKER_PROXY}/https-proxy.conf << __HTTPS_DOCKER_PROXY__
-[Service]
-Environment="HTTPS_PROXY=${HTTPS_PROXY_URL}" "NO_PROXY=${NO_PROXY}"
-__HTTPS_DOCKER_PROXY__
+            sed -i "/^\[Install\]/i Environment=HTTPS_PROXY=${HTTPS_PROXY_URL}" ${CONTAINERD_CONF}
         else
 	    echo -e "\e[91mInvalid HTTPS Proxy URL supplied" > /dev/console
         fi

--- a/files/setup-04-kubernetes.sh
+++ b/files/setup-04-kubernetes.sh
@@ -2,14 +2,13 @@
 # Copyright 2021 VMware, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-2
 
-# Setup Docker and Kubernetes
+# Setup Containerd and Kubernetes
 
 set -euo pipefail
 
-echo -e "\e[92mStarting Docker ..." > /dev/console
-systemctl daemon-reload
-systemctl start docker.service
-systemctl enable docker.service
+echo -e "\e[92mStarting Containerd ..." > /dev/console
+systemctl enable containerd
+systemctl start containerd
 
 echo -e "\e[92mDisabling/Stopping IP Tables  ..." > /dev/console
 systemctl stop iptables

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -37,7 +37,6 @@ WEBHOOK_USERNAME=$(/root/setup/getOvfProperty.py "guestinfo.webhook_username")
 WEBHOOK_PASSWORD=$(/root/setup/getOvfProperty.py "guestinfo.webhook_password")
 CUSTOM_VEBA_TLS_PRIVATE_KEY=$(/root/setup/getOvfProperty.py "guestinfo.custom_tls_private_key")
 CUSTOM_VEBA_TLS_CA_CERT=$(/root/setup/getOvfProperty.py "guestinfo.custom_tls_ca_cert")
-DOCKER_NETWORK_CIDR=$(/root/setup/getOvfProperty.py "guestinfo.docker_network_cidr")
 POD_NETWORK_CIDR=$(/root/setup/getOvfProperty.py "guestinfo.pod_network_cidr")
 SYSLOG_SERVER_HOSTNAME=$(/root/setup/getOvfProperty.py "guestinfo.syslog_server_hostname")
 SYSLOG_SERVER_PORT=$(/root/setup/getOvfProperty.py "guestinfo.syslog_server_port")
@@ -128,7 +127,6 @@ else
 	"ESCAPED_WEBHOOK_PASSWORD": ${ESCAPED_WEBHOOK_PASSWORD},
 	"CUSTOM_VEBA_TLS_PRIVATE_KEY": "${CUSTOM_VEBA_TLS_PRIVATE_KEY}",
 	"CUSTOM_VEBA_TLS_CA_CERT": "${CUSTOM_VEBA_TLS_CA_CERT}",
-	"DOCKER_NETWORK_CIDR": "${DOCKER_NETWORK_CIDR}",
 	"POD_NETWORK_CIDR": "${POD_NETWORK_CIDR}",
 	"SYSLOG_SERVER_HOSTNAME": "${SYSLOG_SERVER_HOSTNAME}",
 	"SYSLOG_SERVER_PORT": "${SYSLOG_SERVER_PORT}",

--- a/manual/photon.xml.template
+++ b/manual/photon.xml.template
@@ -158,10 +158,6 @@
             <Label>Debugging</Label>
             <Description>Enable Debugging</Description>
         </Property>
-        <Property ovf:key="guestinfo.docker_network_cidr" ovf:type="string" ovf:userConfigurable="true" ovf:value="172.17.0.1/16">
-            <Label>Docker Bridge CIDR Network</Label>
-            <Description>Customize Docker Bridge CIDR Network (Default 172.17.0.1/16)</Description>
-        </Property>
         <Property ovf:key="guestinfo.pod_network_cidr" ovf:type="string" ovf:userConfigurable="true" ovf:value="10.10.0.0/16">
             <Label>POD CIDR Network</Label>
             <Description>Customize POD CIDR Network (Default 10.10.0.0/16)</Description>

--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -14,7 +14,7 @@ do
             value=$(jq -r ".$component_name.containers[$i]" ${VEBA_BOM_FILE});
             container_name=$(jq -r '.name' <<< "$value");
             container_version=$(jq -r '.version' <<< "$value");
-            docker pull "$container_name:$container_version"
+            crictl pull "$container_name:$container_version"
         done
     fi
 done

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -48,35 +48,42 @@
                 "version": "v0.37.5"
             }]
     },
+    "kind": {
+        "gitRepoTag": "main",
+        "containers": [{
+            "name": "kindest/node",
+            "version": "v1.21.2"
+        }]
+    },
     "kubernetes": {
-        "gitRepoTag": "v1.20.2",
+        "gitRepoTag": "v1.21.5",
         "containers": [{
                 "name": "k8s.gcr.io/kube-apiserver",
-                "version": "v1.20.2"
+                "version": "v1.21.5"
             },
             {
                 "name": "k8s.gcr.io/kube-controller-manager",
-                "version": "v1.20.2"
+                "version": "v1.21.5"
             },
             {
                 "name": "k8s.gcr.io/kube-scheduler",
-                "version": "v1.20.2"
+                "version": "v1.21.5"
             },
             {
                 "name": "k8s.gcr.io/kube-proxy",
-                "version": "v1.20.2"
+                "version": "v1.21.5"
             },
             {
                 "name": "k8s.gcr.io/pause",
-                "version": "3.2"
+                "version": "3.4.1"
             },
             {
                 "name": "k8s.gcr.io/etcd",
                 "version": "3.4.13-0"
             },
             {
-                "name": "k8s.gcr.io/coredns",
-                "version": "1.7.0"
+                "name": "k8s.gcr.io/coredns/coredns",
+                "version": "v1.8.0"
             }
         ]
     },
@@ -188,5 +195,8 @@
     },
     "ytt-cli": {
         "version": "v0.35.1"
+    },
+    "containerd": {
+        "version": "1.5.7"
     }
 }

--- a/vmware-event-router/hack/run_integration_tests.sh
+++ b/vmware-event-router/hack/run_integration_tests.sh
@@ -16,9 +16,9 @@ GREEN='\033[32m'
 RESET='\033[0m'
 
 # OpenFaaS
-OF_VERSION=$(${JQBIN} '.openfaas.gitRepoTag' ${BOM_FILE})                # faas-netes version to use
+OF_VERSION=0.14.1                                                     # faas-netes version to use
 OF_TIMEOUT=3m                                                         # exit if OpenFaaS is not ready within this time
-CLI_VERSION=$(${JQBIN} '.openfaas."faas-cli"["version"]' ${BOM_FILE}) # faas-cli version
+CLI_VERSION=0.14.1                                                    # faas-cli version
 PORT_FWD="deploy/gateway 8080:8080"                                   # local/remote ports to use for port-forwarding to OpenFaaS gateway
 OKFN=of-echo                                                          # OpenFaaS function
 FAILFN=of-fail                                                        # OpenFaaS function
@@ -28,12 +28,13 @@ FN_TIMEOUT=1m                                                         # exit if 
 AWS_SECRET=secret_aws.json # when running AWS integration tests, secret file holding AWS config at index [1]
 
 # Kubernetes (kind)
-K8S_VERSION=$(${JQBIN} '.kubernetes.gitRepoTag' ${BOM_FILE})
+K8S_IMAGE=$(${JQBIN} '.kind.containers[0].name' ${BOM_FILE})
+K8S_TAG=$(${JQBIN} '.kind.containers[0].version' ${BOM_FILE})
 KINDBIN="kind"
 KIND_TIMEOUT=5m # exit if kind cluster creation does not complete within this time
 KIND_WAIT=2m    # wait for control plane to show ready
 KIND_CLUSTER="veba-integration"
-KIND_IMAGE="kindest/node:${K8S_VERSION}"
+KIND_IMAGE="${K8S_IMAGE}:${K8S_TAG}"
 #################################
 
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -61,7 +62,7 @@ function cleanup() {
 trap cleanup INT TERM EXIT
 
 # create kind cluster
-cecho "---> Creating Kubernetes cluster (${K8S_VERSION}) with max wait time: ${KIND_TIMEOUT}" ${GREEN}
+cecho "---> Creating Kubernetes cluster (${K8S_TAG}) with max wait time: ${KIND_TIMEOUT}" ${GREEN}
 ${TIMEOUT_CMD} ${KIND_TIMEOUT} ${KINDBIN} create cluster --name ${KIND_CLUSTER} --wait ${KIND_WAIT} --image ${KIND_IMAGE}
 
 # generate password used by OpenFaaS for basic_auth


### PR DESCRIPTION
Closes: #674 

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation changes
- [ ] Other (please describe):

## Testing

Verified VEBA appliance build is successful in switching container runtime
```
root@veba [ ~ ]# kubectl get nodes -o json | jq -r .items[].status.nodeInfo
{
  "architecture": "amd64",
  "bootID": "d9d7d255-702b-4cc9-ad9d-35d6a1926365",
  "containerRuntimeVersion": "containerd://1.5.7",
  "kernelVersion": "5.10.61-3.ph4-esx",
  "kubeProxyVersion": "v1.21.5",
  "kubeletVersion": "v1.21.5",
  "machineID": "289cc3f5f06646188f858cb3b363eab8",
  "operatingSystem": "linux",
  "osImage": "VMware Photon OS/Linux",
  "systemUUID": "11352942-db51-4fac-d5eb-109afeb7e7db"
}
```