### PR TITLE
Make concurrency values consistent in kn-go-nsx-tag-sync

### DIFF
--- a/examples/knative/go/kn-go-nsx-tag-sync/README.md
+++ b/examples/knative/go/kn-go-nsx-tag-sync/README.md
@@ -242,7 +242,7 @@ autoscaler will then create multiple instances of the function.
 
 ### Example
 
-To handle up to **100 concurrent** tagging events if the default values (FIFO
+To handle up to **200 concurrent** tagging events if the default values (FIFO
 semantics) are not appropriate:
 
 *Trigger settings:*


### PR DESCRIPTION
Closes #876

Signed-off-by: Patrick Kremer <pkremer@vmware.com>

## Summary

The text of the readme shows "100 concurrent" events, but the trigger settings code snippet shows "200". This fix aligns the values.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation changes
- [ ] Other (please describe):
