### PR TITLE
feat: Bump Knative Eventing/Serving to v1.8.3

### DIFF
--- a/files/downloads/knative-contour/overlay.yaml
+++ b/files/downloads/knative-contour/overlay.yaml
@@ -7,30 +7,20 @@ spec:
     spec:
       #@overlay/match missing_ok=True
       dnsPolicy: ClusterFirstWithHostNet
-      #@overlay/match missing_ok=True
-      hostNetwork: true
       containers:
       #@overlay/match by="name"
       - name: envoy
         ports:
         #@overlay/match by="name"
         - name: http
-          containerPort: 80
+          containerPort: 8080
+          #@overlay/match missing_ok=True
+          hostPort: 80
         #@overlay/match by="name"
         - name: https
-          containerPort: 443
-
-#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name": "envoy", "namespace": "contour-external"}})
----
-spec:
-  type: NodePort
-  ports:
-  #@overlay/match by="name"
-  - name: http
-    targetPort: 80
-  #@overlay/match by="name"
-  - name: https
-    targetPort: 44
+          containerPort: 8443
+          #@overlay/match missing_ok=True
+          hostPort: 443
 
 #@overlay/match by=overlay.subset({"kind":"Job", "metadata": {"namespace": "contour-external"}})
 ---
@@ -42,18 +32,6 @@ spec:
       -
         #@overlay/match missing_ok=True
         imagePullPolicy: IfNotPresent
-
-#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "contour", "namespace": "contour-external"}})
----
-spec:
-  template:
-    spec:
-      containers:
-      #@overlay/match by=overlay.subset({"name": "contour"})
-      - args:
-        #@overlay/append
-        - --envoy-service-http-port=80
-        - --envoy-service-https-port=443
 
 #@overlay/match by=overlay.subset({"kind":"Job", "metadata": {"namespace": "contour-internal"}})
 ---

--- a/files/setup-05-knative.sh
+++ b/files/setup-05-knative.sh
@@ -34,6 +34,8 @@ kubectl wait deployment --all --timeout=${KUBECTL_WAIT} --for=condition=Availabl
 
 echo -e "\e[92mDeploying RabbitMQ Broker ..." > /dev/console
 kubectl apply -f /root/download/rabbitmq-broker.yaml
+kubectl wait --for=condition=available deploy/rabbitmq-broker-controller --timeout=${KUBECTL_WAIT} -n knative-eventing
+kubectl wait --for=condition=available deploy/rabbitmq-broker-webhook --timeout=${KUBECTL_WAIT} -n knative-eventing
 
 echo -e "\e[92mDeploying RabbitMQ Cluster ..." > /dev/console
 RABBITMQ_CONFIG_TEMPLATE=/root/config/knative/templates/rabbit-template.yaml

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -81,73 +81,73 @@
         ]
     },
     "knative-cli": {
-        "version": "v1.1.0"
+        "version": "v1.8.1"
     },
     "knative-serving": {
-        "gitRepoTag": "v1.1.0",
+        "gitRepoTag": "v1.8.3",
             "containers": [{
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256",
-                "version": "48a1753de35ecbe060611aea9e95751e3e4851183c4373e65aa1b9410ea6e263"
+                "version": "f78383554ed81895ff230217f3e0ce9bf9ff2048d4303cc9fb36342ac3f470b3"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256",
-                "version": "ba1485ded12049525afb9856c2fa10d613dbc2b2da90556116bf257f2128eaae"
+                "version": "24c6c8de9a6872ca796a13d1e8324a4dd250aacc5094975b60ce235122abb97f"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256",
-                "version": "dca8258a46dd225b8a72dfe63e8971b23876458f6f64b4ad82792c4d6e470bdc"
+                "version": "f26a8b516112413cbba4244b36202354d1c98ed209301b255c55958213708a78"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256",
-                "version": "2765feeaa3958827388e6f5119010ee08c0eec9ad7518bb38ac4b9a4355d87fb"
+                "version": "ea48ea2f2433cc7e5c25940e79465ca7226750260faaa1724b95dd8cfac92034"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256",
-                "version": "25df5b854d28dac69c6293db4db50d8fa819c96ad2f2a30bdde6aad467de1b17"
+                "version": "9197c51406208c8f3cc98c2b1f69ed2ba8b88e11cf765616700abecc5dd18350"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256",
-                "version": "6ccc1f6ac07d27e97d96c502b4c6e928d5fb3abd165ae7670e94a57788416c75"
+                "version": "1b6e7f382c878f8ac168ce36a92f1af4dbdac0f61aae9e73fe899486786a4bbf"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256",
-                "version": "9f3c83def9d0d5de0e8e1d1f4c10f262e283fe12d21dcbb91de06b65d3bd08ad"
+                "version": "e271d46b5168e25e9742f6f33a461cfcdc17b2460d4355fff7fe0c71fc1e4378"
             }
         ]
     },
     "knative-eventing": {
-        "gitRepoTag": "v1.1.0",
+        "gitRepoTag": "v1.8.3",
             "containers": [{
                 "name": "gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256",
-                "version": "14e565af0a741a0e34b139d9661555189972af8d53e837305f711a3f9025e188"
+                "version": "355466748777f8d198486ee8e49802f1abafc61de2a8d3a38bdb905cbdff7923"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256",
-                "version": "afb65789e9c92414ef8885bb71ec1afd7dffe1730729a45fbf918356bd6ed7a1"
+                "version": "c1064ea5c0df5fa4b53a5aa44e7e2fcef4f515997e74c120698123b013d59bbd"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256",
-                "version": "6a78d2df8eec44bb983ae39952097670fad0556afc6d069fc88fd8347a014698"
+                "version": "c616008cf825fde38999513aa9eda7c44e4285f84f85d1454eef5bfbb3cd1c40"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256",
-                "version": "9ca667c4d9c9c02b1549aee6d3fc13f40e8e54322260525665b029983c373ece"
+                "version": "0f8753e4070b4fa02f56f9a80ce3ad7ea80f817ccc8b8c6e6a3a0dafdf869b57"
             }
         ]
     },
     "knative-contour": {
-        "gitRepoTag": "v1.1.0",
+        "gitRepoTag": "v1.8.1",
             "containers": [{
-                "name": "gcr.io/knative-releases/github.com/projectcontour/contour/cmd/contour@sha256",
-                "version": "5f726d901a2852197447b5d0ca43d7d0b3bb0756290fbd7984371ab5a49db853"
+                "name": "ghcr.io/projectcontour/contour",
+                "version": "v1.22.0"
             },
             {
                 "name": "docker.io/envoyproxy/envoy",
-                "version": "v1.19.1"
+                "version": "v1.23.0"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/net-contour/cmd/controller@sha256",
-                "version": "922ce3f28a1dc618e4ebd62cfdf10216f06543bb70e280277107c4ec3d2e4eac"
+                "version": "b76866e644a6366cd55754efe5b5e3714fd69a7892a927221749c13ed3b7cead"
             }
         ]
     },
@@ -160,10 +160,10 @@
         ]
     },
     "rabbitmq-operator": {
-        "gitRepoTag": "v1.10.0",
+        "gitRepoTag": "v1.14.0",
         "containers": [{
                 "name": "rabbitmqoperator/cluster-operator",
-                "version": "1.10.0"
+                "version": "1.14.0"
             },
             {
                 "name": "rabbitmq",
@@ -172,46 +172,46 @@
         ]
     },
     "rabbitmq-broker": {
-        "gitRepoTag": "v1.1.0",
+        "gitRepoTag": "v1.8.3",
         "containers": [{
                 "name": "gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/controller/broker@sha256",
-                "version": "352d7fd1bf8dfb46a84c324ab11d3e35da786a95428771c66d5b832d1a0f456e"
+                "version": "a990033b4b0974e22b5440ed0cc46b0813762120d59e77b5fb7a00b068020aaf"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/ingress@sha256",
-                "version": "dc26d1d72e0ec52836970be0e4fbf966acea221ff9dc167234c5d5fede6d16f8"
+                "version": "7e510f999b98b83a0df16645989f58efd24e8445b798b77144a4d792479496f3"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/dispatcher@sha256",
-                "version": "1001eed441e4b438eda8520a3d02ad9f07ef0faae200864fd03caae04d4a7323"
+                "version": "7cd0225d481ad0dff8c64344c764674d2316e31d636ea7a891c13c53cd9094b0"
             },
             {
                 "name": "gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/webhook/broker@sha256",
-                "version": "b69e108a1c439a722346725ed59ad140cd98c7d7220037241842a4489adc441a"
+                "version": "0d80a0cf4159a371d1f5e0841e96018973c2c2db727824a991a3ebd92357333c"
             }
         ]
     },
     "rabbitmq-messaging-topology-operator": {
-        "gitRepoTag": "v1.2.1",
+        "gitRepoTag": "v1.10.0",
         "containers": [{
                 "name": "rabbitmqoperator/messaging-topology-operator",
-                "version": "1.2.1"
+                "version": "1.10.0"
             }
         ]
     },
     "cert-manager": {
-        "gitRepoTag": "v1.5.4",
+        "gitRepoTag": "v1.11.0",
         "containers": [{
                 "name": "quay.io/jetstack/cert-manager-cainjector",
-                "version": "v1.5.4"
+                "version": "v1.11.0"
             },
             {
                 "name": "quay.io/jetstack/cert-manager-controller",
-                "version": "v1.5.4"
+                "version": "v1.11.0"
             },
             {
                 "name": "quay.io/jetstack/cert-manager-webhook",
-                "version": "v1.5.4"
+                "version": "v1.11.0"
             }
         ]
     },


### PR DESCRIPTION
## Summary

This change adds support for latest Knative Eventing/Serving at v1.8.3 which also requires updates to several other dependencies:

- knative-contour v1.8.1
- rabbitmq-operator v1.14.0
- rabbitmq-broker v1.8.3
- rabbitmq-messaging-topology-operator v1.10.0
- cert-manager v1.10.0

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

Closes #984 
## Testing Verification

* Successfully built VEBA appliance with BOM and deployed appliance and verified that everything was up and running as expected

```
# k get pods -A
NAMESPACE            NAME                                                  READY   STATUS      RESTARTS      AGE
cert-manager         cert-manager-99bb69456-kj9ms                          1/1     Running     0             2m29s
cert-manager         cert-manager-cainjector-ffb4747bb-g6q8g               1/1     Running     0             2m29s
cert-manager         cert-manager-webhook-545bd5d7d8-f6rcn                 1/1     Running     0             2m29s
contour-external     contour-6c6495d496-2mbmg                              1/1     Running     0             3m20s
contour-external     contour-6c6495d496-snklc                              1/1     Running     0             3m20s
contour-external     contour-certgen-v1.22.0-q7t7k                         0/1     Completed   0             3m20s
contour-external     envoy-ntqtr                                           2/2     Running     0             3m19s
contour-internal     contour-c4478d89b-86zh8                               1/1     Running     0             3m19s
contour-internal     contour-c4478d89b-v764j                               1/1     Running     0             3m19s
contour-internal     contour-certgen-v1.22.0-564mc                         0/1     Completed   0             3m19s
contour-internal     envoy-rn6m6                                           2/2     Running     0             3m19s
knative-eventing     eventing-controller-fdc4dd6bb-gkvnt                   1/1     Running     0             2m53s
knative-eventing     eventing-webhook-676dfb6c4f-t8sbp                     1/1     Running     0             2m53s
knative-eventing     rabbitmq-broker-controller-54c85d4f98-chbls           1/1     Running     0             2m17s
knative-eventing     rabbitmq-broker-webhook-877b8d7df-sm29v               1/1     Running     0             2m17s
knative-serving      activator-7cbbfbc85-tknkn                             1/1     Running     0             3m45s
knative-serving      autoscaler-8f986cff-wbztx                             1/1     Running     0             3m44s
knative-serving      controller-58dfb45d74-g847k                           1/1     Running     0             3m45s
knative-serving      domain-mapping-5d8db49bf6-j8qbs                       1/1     Running     0             3m45s
knative-serving      domainmapping-webhook-584476fd67-zkdkv                1/1     Running     0             3m45s
knative-serving      net-contour-controller-6768758c67-sxsqq               1/1     Running     0             3m19s
knative-serving      webhook-6d5c55fd8c-h467d                              1/1     Running     0             3m44s
kube-system          antrea-agent-pwlqg                                    2/2     Running     0             3m45s
kube-system          antrea-controller-6db8bb65cf-k2wlw                    1/1     Running     0             3m45s
kube-system          coredns-565d847f94-hpbpb                              1/1     Running     0             3m45s
kube-system          coredns-565d847f94-kmzx8                              1/1     Running     0             3m45s
kube-system          etcd-veba.primp-industries.local                      1/1     Running     0             4m1s
kube-system          kube-apiserver-veba.primp-industries.local            1/1     Running     0             4m2s
kube-system          kube-controller-manager-veba.primp-industries.local   1/1     Running     0             3m59s
kube-system          kube-proxy-n7p4c                                      1/1     Running     0             3m45s
kube-system          kube-scheduler-veba.primp-industries.local            1/1     Running     0             3m59s
local-path-storage   local-path-provisioner-56c55476f9-fpgqq               1/1     Running     0             3m45s
rabbitmq-system      messaging-topology-operator-74c896bb55-kjq4p          1/1     Running     0             2m21s
rabbitmq-system      rabbitmq-cluster-operator-586b7547f8-q8lhq            1/1     Running     0             2m30s
vmware-functions     default-broker-ingress-849d94cc6f-bt9jc               1/1     Running     0             91s
vmware-functions     sockeye-79b7fc7c55-kdth4                              1/1     Running     0             2m16s
vmware-functions     sockeye-trigger-dispatcher-6c78c687c5-c9fs9           1/1     Running     0             89s
vmware-system        tinywww-5b795ddd75-tvqvx                              1/1     Running     0             46s
vmware-system        veba-rabbit-server-0                                  1/1     Running     0             2m16s
vmware-system        veba-ui-846bb59f69-x5f5k                              1/1     Running     0             44s
vmware-system        vmware-event-router-vcenter-7795f87c87-b6xjn          1/1     Running     4 (93s ago)   2m14s
vmware-system        vmware-event-router-webhook-769d559d7-rmn22           1/1     Running     0             48s
```