### PR TITLE
fix: Remove kind node image from VEBA appliance

### DIFF
--- a/scripts/photon-containers.sh
+++ b/scripts/photon-containers.sh
@@ -14,7 +14,9 @@ do
             value=$(jq -r ".$component_name.containers[$i]" ${VEBA_BOM_FILE});
             container_name=$(jq -r '.name' <<< "$value");
             container_version=$(jq -r '.version' <<< "$value");
-            crictl pull "$container_name:$container_version"
+            if [ "${container_name}" != "kindest/node" ]; then
+                crictl pull "$container_name:$container_version"
+            fi
         done
     fi
 done


### PR DESCRIPTION
## Summary

This change removes the need to pull the `kind` node container image into VEBA appliance as that is only needed for local development purposes.

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

Closes #993 

## Testing Verification

* Successfully built and deployed VEBA appliance and ensure kind node is no longer being pulled

```
# crictl images
IMAGE                                                                         TAG                 IMAGE ID            SIZE
docker.io/envoyproxy/envoy                                                    v1.23.0             b9424d88ca2bb       52.8MB
docker.io/fluent/fluent-bit                                                   2.0.8               d7e57702e67bf       29.4MB
docker.io/library/busybox                                                     latest              66ba00ad3de86       2.6MB
docker.io/library/rabbitmq                                                    3.8.21-management   b752ffe108c3a       110MB
docker.io/n3wscott/sockeye                                                    <none>              457fd63ce5516       7.09MB
docker.io/rabbitmqoperator/cluster-operator                                   1.14.0              2a7bce866dd52       22.2MB
docker.io/rabbitmqoperator/messaging-topology-operator                        1.10.0              6cfb8da9a6141       24.3MB
docker.io/rancher/local-path-provisioner                                      v0.0.23             9621e18c33880       13.9MB
gcr.io/cadvisor/cadvisor                                                      v0.47.0             b2a3c8cd61532       34MB
gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/controller/broker   <none>              91a8b485de682       17.4MB
gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/dispatcher          <none>              8a013c1c8cb93       16.4MB
gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/ingress             <none>              27ebd16787b2c       16.3MB
gcr.io/knative-releases/knative.dev/eventing-rabbitmq/cmd/webhook/broker      <none>              b8c561a597736       16.9MB
gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter    <none>              d77383f1b1b0d       16.2MB
gcr.io/knative-releases/knative.dev/eventing/cmd/controller                   <none>              d52d12fa65949       17.9MB
gcr.io/knative-releases/knative.dev/eventing/cmd/mtping                       <none>              65c1d5147266f       17.2MB
gcr.io/knative-releases/knative.dev/eventing/cmd/webhook                      <none>              3a2e7c6e3e1ee       17.6MB
gcr.io/knative-releases/knative.dev/net-contour/cmd/controller                <none>              ba29bf08895b1       16.5MB
gcr.io/knative-releases/knative.dev/serving/cmd/activator                     <none>              776f022c8a542       16.8MB
gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler                    <none>              e4ea927c455d7       17.1MB
gcr.io/knative-releases/knative.dev/serving/cmd/controller                    <none>              9841a4249b9e2       18.8MB
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook        <none>              e5b384d3335b6       16.2MB
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping                <none>              d9145b4695841       16.7MB
gcr.io/knative-releases/knative.dev/serving/cmd/queue                         <none>              4de1796973ea9       10.4MB
gcr.io/knative-releases/knative.dev/serving/cmd/webhook                       <none>              a3cdd4faac9d2       16.6MB
ghcr.io/projectcontour/contour                                                v1.22.0             9190a978ca938       14MB
projects.registry.vmware.com/antrea/antrea-ubuntu                             v1.10.0             842a38b405912       208MB
projects.registry.vmware.com/veba/kn-echo                                     latest              8aba5b25831a1       107MB
projects.registry.vmware.com/veba/tinywww                                     latest              b73df0803467e       31.2MB
projects.registry.vmware.com/veba/veba-ui                                     2802221f            f35aae11a81b4       177MB
quay.io/jetstack/cert-manager-cainjector                                      v1.11.0             9604d46e1ddae       12.6MB
quay.io/jetstack/cert-manager-controller                                      v1.11.0             ea6670b273491       18.3MB
quay.io/jetstack/cert-manager-webhook                                         v1.11.0             a26ccff6c31b4       14.3MB
registry.k8s.io/coredns/coredns                                               v1.8.6              a4ca41631cc7a       13.6MB
registry.k8s.io/etcd                                                          3.5.6-0             fce326961ae2d       103MB
registry.k8s.io/kube-apiserver                                                v1.24.9             ae6cdd144f9d7       33.8MB
registry.k8s.io/kube-controller-manager                                       v1.24.9             16e04a3cf5de3       31.1MB
registry.k8s.io/kube-proxy                                                    v1.24.9             ca65e238774be       39.5MB
registry.k8s.io/kube-scheduler                                                v1.24.9             affce73c10985       15.5MB
registry.k8s.io/pause                                                         3.6                 6270bb605e12e       302kB
registry.k8s.io/pause                                                         3.7                 221177c6082a8       311kB
us.gcr.io/daisy-284300/veba/router                                            v0.7.4              7b4ed9b88a15d       15.4MB
```