### PR TITLE
fix: Replace Containerd config with pause container from VEBA BOM

### DIFF
--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -78,6 +78,12 @@ curl -L https://github.com/containerd/containerd/releases/download/v${CONTAINERD
 tar -zxvf /root/download/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz -C /usr
 rm -f /root/download/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz
 containerd config default > /etc/containerd/config.toml
+
+# Update default version of the pause container to the one from VEBA BOM
+PAUSE_CONTAINER_NAME="registry.k8s.io/pause"
+PAUSE_CONTAINER_VERSION=$(jq -r --arg PAUSE_CONTAINER_NAME ${PAUSE_CONTAINER_NAME} '.kubernetes.containers[] | select(.name == $PAUSE_CONTAINER_NAME) | .version' ${VEBA_BOM_FILE})
+sed -i "s#sandbox_image.*#sandbox_image = \"${PAUSE_CONTAINER_NAME}:${PAUSE_CONTAINER_VERSION}\"#g" /etc/containerd/config.toml
+
 cat > /usr/lib/systemd/system/containerd.service <<EOF
 [Unit]
 Description=containerd container runtime

--- a/veba-bom.json
+++ b/veba-bom.json
@@ -67,10 +67,6 @@
                 "version": "3.8"
             },
             {
-                "name": "registry.k8s.io/pause",
-                "version": "3.7"
-            },
-            {
                 "name": "registry.k8s.io/etcd",
                 "version": "3.5.6-0"
             },


### PR DESCRIPTION
## Summary

This change replaces the "default" pause container version for containerd with the version specified in the VEBA BOM. This also ensures that VEBA can run in an air-gapped environment as it will not attempt to pull default version of pause container

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [ ] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [ ] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [ ] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [ ] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes #ISSUE-NUMBER)

Closes: #1085

## Testing Verification

* Deployed VEBA appliance and ensure only pause container 3.8 is deployed and no other versions are required

## Additional Information

* Any other details you wish to include or mention

If you have any questions/comments, feel free to reach out to team on Slack [#vcenter-event-broker-appliance](https://vmwarecode.slack.com/archives/CQLT9B5AA)

Thank you from the VEBA Team! 🥳