### PR TITLE
Add new wait condition to setup-05-knative.sh

### DIFF
--- a/files/setup-05-knative.sh
+++ b/files/setup-05-knative.sh
@@ -43,6 +43,7 @@ RABBITMQ_CONFIG_TEMPLATE=/root/config/knative/templates/rabbit-template.yaml
 RABBITMQ_CONFIG=/root/config/knative/rabbit.yaml
 ytt --data-value-file bom=${VEBA_BOM_FILE} -f ${RABBITMQ_CONFIG_TEMPLATE} > ${RABBITMQ_CONFIG}
 kubectl apply -f ${RABBITMQ_CONFIG}
+kubectl wait --for=condition=ClusterAvailable rabbitmqcluster/veba-rabbit --timeout=${KUBECTL_WAIT} -n vmware-system
 kubectl wait --for=condition=Ready broker/default --timeout=${KUBECTL_WAIT} -n vmware-functions
 
 echo -e "\e[92mDeploying Sockeye ..." > /dev/console


### PR DESCRIPTION
## Summary
PR will introduce a new waiting condition to the script which is doing the Knative setup. The wait condition is for the `RabbitMQCluster` object. 

## Pull Request Checklist
🚨 Please review the [guidelines for contributing](https://vmweventbroker.io/community) to this repository.

- [x] Please ensure that you are making a pull request against the **Development** branch
- [ ] Please use the `WIP` keyword in the title of your PR if you are not ready for review
- [x] Please ensure that you have opened a Github Issue if you are resolving/fixing a problem
- [x] Please ensure that you have [signed](https://help.github.com/en/github/authenticating-to-github/signing-commits) all commits and that you have [squashed](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec) all relevant commits related to your change
- [x] Please make sure that you have tested your change locally by successfully [building and deploying the VMware Event Broker Appliance](https://vmweventbroker.io/kb/contribute-appliance) and/or [building and deploying VMware Event Router](https://vmweventbroker.io/kb/contribute-eventrouter)
- [ ] Please include any relevant screenshots and/or output as part of your testing
- [ ] Please include any documentation updates that is applicable for your changes

## Change Type

What types of changes does your code introduce to the VMware Event Broker Appliance?

_Put an `x` in all boxes that apply_

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe):

## Resolved Issues

List of Issues closed or resolved by this PR. Add multiple `Closes` keyword followed by the issue number (e.g. Closes Closes: #1167

## Testing Verification

* Ran new build
* Validated the new change during bootstrap process of VEBA
* Deployment (air-gapped) successfully multiple times
